### PR TITLE
feat(move-core-types): add no-std support

### DIFF
--- a/language/move-core/types/Cargo.toml
+++ b/language/move-core/types/Cargo.toml
@@ -10,32 +10,35 @@ publish = ["crates-io"]
 edition = "2021"
 
 [dependencies]
-anyhow = "1.0.52"
-hex = "0.4.3"
-once_cell = "1.7.2"
-proptest = { version = "1.0.0", default-features = false, optional = true }
-proptest-derive = { version = "0.3.0", default-features = false, optional = true }
-rand = "0.8.3"
-ref-cast = "1.0.6"
-serde = { version = "1.0.124", default-features = false }
-serde_bytes = "0.11.5"
-primitive-types = {version = "0.10.1", features = ["impl-serde"]}
-uint = "0.9.4"
-num = "0.4.0"
-ethnum = "1.0.4"
-arbitrary = { version = "1.1.7", features = [ "derive_arbitrary"], optional = true }
-
-bcs.workspace = true
+anyhow = { version = "1.0", default-features = false }
+hex = { version = "0.4", default-features = false, features = ["alloc"] }
+proptest = { version = "1.2", default-features = false, optional = true }
+proptest-derive = { version = "0.3", default-features = false, optional = true }
+rand = { version = "0.8", default-features = false }
+ref-cast = "1.0"
+serde = { version = "1.0", default-features = false, features = ["derive"] }
+serde_bytes = { version = "0.11", default-features = false, features = ["alloc"] }
+primitive-types = { version = "0.12", default-features = false }
+uint = { version = "0.9", default-features = false }
+num = { version = "0.4", default-features = false, features = ["alloc"] }
+ethnum = { version = "1.3", default-features = false }
+hashbrown = { version = "0.14" , default-features = false }
+bcs = { default-features = false, git = "https://github.com/eigerco/bcs.git", branch = "master"}
 
 [dev-dependencies]
-proptest = "1.0.0"
-proptest-derive = "0.3.0"
-regex = "1.5.5"
-serde_json = "1.0.64"
-arbitrary = { version = "1.1.7", features = [ "derive_arbitrary"] }
+proptest = "1.2"
+proptest-derive = "0.3"
+regex = "1.9"
 
 [features]
 address20 = []
 address32 = []
-default = []
-fuzzing = ["proptest", "proptest-derive", "arbitrary"]
+default = ["std", "address32"]
+fuzzing = ["proptest", "proptest-derive"]
+
+std = [
+    "anyhow/std",
+    "uint/std",
+    "primitive-types/std",
+    "bcs/std",
+]

--- a/language/move-core/types/src/abi.rs
+++ b/language/move-core/types/src/abi.rs
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::language_storage::{ModuleId, TypeTag};
+use alloc::string::String;
+use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};
 
 /// How to call a particular Move script (aka. an "ABI").

--- a/language/move-core/types/src/effects.rs
+++ b/language/move-core/types/src/effects.rs
@@ -7,8 +7,10 @@ use crate::{
     identifier::Identifier,
     language_storage::{ModuleId, StructTag, TypeTag},
 };
+use alloc::borrow::ToOwned;
+use alloc::collections::btree_map::{self, BTreeMap};
+use alloc::vec::Vec;
 use anyhow::{bail, Result};
-use std::collections::btree_map::{self, BTreeMap};
 
 /// A storage operation.
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
@@ -187,6 +189,12 @@ impl AccountChangeSet {
     }
 }
 
+impl Default for AccountChangeSet {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 // TODO: ChangeSet does not have a canonical representation so the derived Ord is not sound.
 
 /// A collection of changes to a Move state. Each AccountChangeSet in the domain of `accounts`
@@ -292,6 +300,12 @@ impl ChangeSet {
                 .iter()
                 .map(move |(struct_tag, op)| (addr, struct_tag, op.as_ref().map(|v| v.as_ref())))
         })
+    }
+}
+
+impl Default for ChangeSet {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/language/move-core/types/src/errmap.rs
+++ b/language/move-core/types/src/errmap.rs
@@ -1,16 +1,19 @@
 // Copyright (c) The Diem Core Contributors
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
+// TODO: Remove this file possibly, currently mod unused
 
 use crate::language_storage::ModuleId;
 use anyhow::{bail, Result};
 use serde::{Deserialize, Serialize};
-use std::{
-    collections::BTreeMap,
+use sp_std::{
     fs::File,
     io::{Read, Write},
     path::Path,
 };
+use alloc::vec::Vec;
+use alloc::string::String;
+use alloc::collections::btree_map::BTreeMap;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ErrorDescription {

--- a/language/move-core/types/src/gas_algebra.rs
+++ b/language/move-core/types/src/gas_algebra.rs
@@ -1,14 +1,14 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use serde::{Deserialize, Serialize};
-use std::{
+use core::{
     cmp::{Eq, Ord, Ordering, PartialEq, PartialOrd},
     convert::From,
     fmt::{self, Debug, Display},
     marker::PhantomData,
     ops::{Add, AddAssign, Mul},
 };
+use serde::{Deserialize, Serialize};
 
 // TODO(Gas): deprecate the concept of abstract memory size
 
@@ -145,7 +145,7 @@ impl<U> Display for GasQuantity<U> {
 
 impl<U> Debug for GasQuantity<U> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{} ({})", self.val, std::any::type_name::<U>())
+        write!(f, "{} ({})", self.val, core::any::type_name::<U>())
     }
 }
 

--- a/language/move-core/types/src/language_storage.rs
+++ b/language/move-core/types/src/language_storage.rs
@@ -7,13 +7,17 @@ use crate::{
     identifier::{IdentStr, Identifier},
     parser::{parse_struct_tag, parse_type_tag},
 };
+use alloc::borrow::ToOwned;
+use alloc::boxed::Box;
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::{
+    fmt::{self, Display, Formatter},
+    str::FromStr,
+};
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
-use std::{
-    fmt::{Display, Formatter},
-    str::FromStr,
-};
 
 pub const CODE_TAG: u8 = 0;
 pub const RESOURCE_TAG: u8 = 1;
@@ -104,7 +108,7 @@ impl StructTag {
         key
     }
 
-    /// Returns true if this is a `StructTag` for an `std::ascii::String` struct defined in the
+    /// Returns true if this is a `StructTag` for an `alloc::ascii::String` struct defined in the
     /// standard library at address `move_std_addr`.
     pub fn is_ascii_string(&self, move_std_addr: &AccountAddress) -> bool {
         self.address == *move_std_addr
@@ -112,7 +116,7 @@ impl StructTag {
             && self.name.as_str().eq("String")
     }
 
-    /// Returns true if this is a `StructTag` for an `std::string::String` struct defined in the
+    /// Returns true if this is a `StructTag` for an `alloc::string::String` struct defined in the
     /// standard library at address `move_std_addr`.
     pub fn is_std_string(&self, move_std_addr: &AccountAddress) -> bool {
         self.address == *move_std_addr
@@ -223,7 +227,7 @@ impl ModuleId {
 }
 
 impl Display for ModuleId {
-    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "{}::{}", self.address, self.name)
     }
 }
@@ -235,7 +239,7 @@ impl ModuleId {
 }
 
 impl Display for StructTag {
-    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(
             f,
             "0x{}::{}::{}",
@@ -256,7 +260,7 @@ impl Display for StructTag {
 }
 
 impl Display for TypeTag {
-    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match self {
             TypeTag::Struct(s) => write!(f, "{}", s),
             TypeTag::Vector(ty) => write!(f, "vector<{}>", ty),
@@ -274,7 +278,7 @@ impl Display for TypeTag {
 }
 
 impl Display for ResourceKey {
-    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "0x{}/{}", self.address.short_str_lossless(), self.type_)
     }
 }
@@ -291,7 +295,7 @@ mod tests {
     use crate::{
         account_address::AccountAddress, identifier::Identifier, language_storage::StructTag,
     };
-    use std::mem;
+    use core::mem;
 
     #[test]
     fn test_type_tag_serde() {

--- a/language/move-core/types/src/lib.rs
+++ b/language/move-core/types/src/lib.rs
@@ -4,10 +4,17 @@
 
 //! Core types for Move.
 
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[macro_use]
+extern crate alloc;
+
 pub mod abi;
 pub mod account_address;
 pub mod effects;
-pub mod errmap;
+// Uses too much IO operations, and doesn't seem to be very important for the runtime, commenting
+// it out for now:
+//pub mod errmap;
 pub mod gas_algebra;
 pub mod identifier;
 pub mod language_storage;

--- a/language/move-core/types/src/metadata.rs
+++ b/language/move-core/types/src/metadata.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use alloc::vec::Vec;
+
 /// Representation of metadata,
 #[derive(Clone, PartialEq, Eq, Debug)]
 #[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]

--- a/language/move-core/types/src/move_resource.rs
+++ b/language/move-core/types/src/move_resource.rs
@@ -7,6 +7,8 @@ use crate::{
     identifier::{IdentStr, Identifier},
     language_storage::{StructTag, TypeTag},
 };
+use alloc::borrow::ToOwned;
+use alloc::vec::Vec;
 use serde::de::DeserializeOwned;
 
 pub trait MoveStructType {

--- a/language/move-core/types/src/resolver.rs
+++ b/language/move-core/types/src/resolver.rs
@@ -6,7 +6,8 @@ use crate::{
     account_address::AccountAddress,
     language_storage::{ModuleId, StructTag},
 };
-use std::fmt::Debug;
+use alloc::vec::Vec;
+use core::fmt::Debug;
 
 /// Traits for resolving Move modules and resources from persistent storage
 

--- a/language/move-core/types/src/state.rs
+++ b/language/move-core/types/src/state.rs
@@ -2,8 +2,6 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use std::cell::RefCell;
-
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum VMState {
     DESERIALIZER,
@@ -12,14 +10,17 @@ pub enum VMState {
     OTHER,
 }
 
-thread_local! {
-    static STATE: RefCell<VMState> = RefCell::new(VMState::OTHER);
-}
+// Small TODO: We should be safe here in a single-threaded wasm environment - but we might
+// need to use RefCell for move-compiler though
+static mut STATE: VMState = VMState::OTHER;
 
 pub fn set_state(state: VMState) -> VMState {
-    STATE.with(|s| s.replace(state))
+    unsafe {
+        STATE = state;
+    }
+    state
 }
 
 pub fn get_state() -> VMState {
-    STATE.with(|s| *s.borrow())
+    unsafe { STATE }
 }

--- a/language/move-core/types/src/transaction_argument.rs
+++ b/language/move-core/types/src/transaction_argument.rs
@@ -3,9 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{account_address::AccountAddress, u256, value::MoveValue};
+use alloc::vec::Vec;
 use anyhow::{anyhow, Error, Result};
+use core::{convert::TryFrom, fmt};
 use serde::{Deserialize, Serialize};
-use std::{convert::TryFrom, fmt};
 
 #[derive(Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub enum TransactionArgument {
@@ -120,7 +121,7 @@ impl VecBytes {
 
 #[cfg(test)]
 mod tests {
-    use std::convert::{From, TryInto};
+    use core::convert::{From, TryInto};
 
     use crate::{
         account_address::AccountAddress, transaction_argument::TransactionArgument, u256::U256,


### PR DESCRIPTION
This updates only `move-core-types`, but not other crates that depend on `move-core-types`. That will be done in a separate PR. With this PR, the crate can be built with `wasm32-unknown-unknown` target and included in a Substrate pallet.