### PR TITLE
feat: make move-borrow-graph no_std compatible

### DIFF
--- a/language/move-borrow-graph/Cargo.toml
+++ b/language/move-borrow-graph/Cargo.toml
@@ -5,3 +5,7 @@ authors = ["Diem Association <opensource@diem.com>"]
 publish = false
 edition = "2021"
 license = "Apache-2.0"
+
+[features]
+default = ["std"]
+std = []

--- a/language/move-borrow-graph/src/graph.rs
+++ b/language/move-borrow-graph/src/graph.rs
@@ -6,7 +6,10 @@ use crate::{
     paths::{self, Path, PathSlice},
     references::*,
 };
-use std::collections::{BTreeMap, BTreeSet};
+
+use alloc::collections::{BTreeMap, BTreeSet};
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
 
 //**************************************************************************************************
 // Definitions
@@ -334,7 +337,7 @@ impl<Loc: Copy, Lbl: Clone + Ord> BorrowGraph<Loc, Lbl> {
     pub fn remap_refs(&mut self, id_map: &BTreeMap<RefID, RefID>) {
         debug_assert!(self.check_invariant());
         let _before = self.0.len();
-        self.0 = std::mem::take(&mut self.0)
+        self.0 = core::mem::take(&mut self.0)
             .into_iter()
             .map(|(id, mut info)| {
                 info.remap_refs(id_map);
@@ -439,11 +442,12 @@ impl<Loc: Copy, Lbl: Clone + Ord> BorrowGraph<Loc, Lbl> {
 
     /// Prints out a view of the borrow graph
     #[allow(dead_code)]
+    #[cfg(feature = "std")]
     pub fn display(&self)
     where
-        Lbl: std::fmt::Display,
+        Lbl: core::fmt::Display,
     {
-        fn path_to_string<Lbl: std::fmt::Display>(p: &PathSlice<Lbl>) -> String {
+        fn path_to_string<Lbl: core::fmt::Display>(p: &PathSlice<Lbl>) -> String {
             p.iter()
                 .map(|l| l.to_string())
                 .collect::<Vec<_>>()

--- a/language/move-borrow-graph/src/lib.rs
+++ b/language/move-borrow-graph/src/lib.rs
@@ -3,6 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[macro_use]
+extern crate alloc;
 
 pub mod graph;
 mod paths;

--- a/language/move-borrow-graph/src/paths.rs
+++ b/language/move-borrow-graph/src/paths.rs
@@ -2,6 +2,9 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use alloc::borrow::ToOwned;
+use alloc::vec::Vec;
+
 pub type PathSlice<Lbl> = [Lbl];
 pub type Path<Lbl> = Vec<Lbl>;
 

--- a/language/move-borrow-graph/src/references.rs
+++ b/language/move-borrow-graph/src/references.rs
@@ -6,12 +6,13 @@ use crate::{
     paths::{self, Path},
     shared::*,
 };
-use std::{
-    cmp::Ordering,
-    collections::{BTreeMap, BTreeSet},
-    fmt,
-    fmt::Debug,
-};
+
+use alloc::collections::{BTreeMap, BTreeSet};
+
+use core::fmt;
+use core::fmt::Debug;
+
+use core::cmp::Ordering;
 
 //**************************************************************************************************
 // Definitions
@@ -130,7 +131,7 @@ impl<Loc: Copy, Lbl: Clone + Ord> BorrowEdgeSet<Loc, Lbl> {
         self.edges.is_empty()
     }
 
-    pub(crate) fn iter(&self) -> std::collections::btree_set::Iter<BorrowEdge<Loc, Lbl>> {
+    pub(crate) fn iter(&self) -> alloc::collections::btree_set::Iter<BorrowEdge<Loc, Lbl>> {
         debug_assert!(self.overflown || !self.is_empty());
         self.edges.iter()
     }
@@ -163,7 +164,7 @@ impl<Loc: Copy, Lbl: Clone + Ord> BorrowEdges<Loc, Lbl> {
     /// If it is not in the map, the id remains the same
     pub(crate) fn remap_refs(&mut self, id_map: &BTreeMap<RefID, RefID>) {
         let _before = self.0.len();
-        self.0 = std::mem::take(&mut self.0)
+        self.0 = core::mem::take(&mut self.0)
             .into_iter()
             .map(|(id, edges)| (id_map.get(&id).copied().unwrap_or(id), edges))
             .collect();
@@ -233,7 +234,7 @@ impl<Loc: Copy, Lbl: Clone + Ord + Debug> Debug for BorrowEdge<Loc, Lbl> {
 
 impl<Loc: Copy, Lbl: Clone + Ord> IntoIterator for BorrowEdgeSet<Loc, Lbl> {
     type Item = BorrowEdge<Loc, Lbl>;
-    type IntoIter = std::collections::btree_set::IntoIter<BorrowEdge<Loc, Lbl>>;
+    type IntoIter = alloc::collections::btree_set::IntoIter<BorrowEdge<Loc, Lbl>>;
 
     fn into_iter(self) -> Self::IntoIter {
         debug_assert!(self.overflown || !self.is_empty());
@@ -243,7 +244,7 @@ impl<Loc: Copy, Lbl: Clone + Ord> IntoIterator for BorrowEdgeSet<Loc, Lbl> {
 
 impl<'a, Loc: Copy, Lbl: Clone + Ord> IntoIterator for &'a BorrowEdgeSet<Loc, Lbl> {
     type Item = &'a BorrowEdge<Loc, Lbl>;
-    type IntoIter = std::collections::btree_set::Iter<'a, BorrowEdge<Loc, Lbl>>;
+    type IntoIter = alloc::collections::btree_set::Iter<'a, BorrowEdge<Loc, Lbl>>;
 
     fn into_iter(self) -> Self::IntoIter {
         debug_assert!(self.overflown || !self.is_empty());

--- a/language/move-borrow-graph/src/shared.rs
+++ b/language/move-borrow-graph/src/shared.rs
@@ -1,11 +1,12 @@
 // Copyright (c) The Diem Core Contributors
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
-use std::collections::{BTreeMap, BTreeSet};
+
+use alloc::collections::{BTreeMap, BTreeSet};
 
 pub fn remap_set<T: Copy + Ord>(set: &mut BTreeSet<T>, id_map: &BTreeMap<T, T>) {
     let _before = set.len();
-    *set = std::mem::take(set)
+    *set = core::mem::take(set)
         .into_iter()
         .map(|x| id_map.get(&x).copied().unwrap_or(x))
         .collect();


### PR DESCRIPTION
Ability to build `move-borrow-graph` with no_std option which is essential for building Move to wasm target (to include it inside the Substrate pallet).