### PR TITLE
feat(move-binary-format): no-std adaptation

### DIFF
--- a/language/move-binary-format/Cargo.toml
+++ b/language/move-binary-format/Cargo.toml
@@ -10,22 +10,27 @@ publish = ["crates-io"]
 edition = "2021"
 
 [dependencies]
-anyhow = "1.0.52"
-once_cell = "1.7.2"
-proptest = { version = "1.0.0", optional = true }
-proptest-derive = { version = "0.3.0", optional = true }
-ref-cast = "1.0.6"
-variant_count = "1.1.0"
-move-core-types = { path = "../move-core/types" }
-serde = { version = "1.0.124", default-features = false }
-arbitrary = { version = "1.1.7", optional = true, features = ["derive"] }
+anyhow = { version = "1.0", default-features = false }
+proptest = { version = "1.2", default-features = false, optional = true }
+proptest-derive = { version = "0.4", default-features = false, optional = true }
+ref-cast = "1.0"
+variant_count = "1.1"
+move-core-types = { path = "../move-core/types", default-features = false }
+serde = { version = "1.0", default-features = false }
+arbitrary = { version = "1.3", optional = true, features = ["derive"] }
+hashbrown = { version = "0.14", features = ["ahash"] }
 
 [dev-dependencies]
-proptest = "1.0.0"
-proptest-derive = "0.3.0"
+proptest = "1.0"
+proptest-derive = "0.4"
 move-core-types = { path = "../move-core/types", features = ["fuzzing" ] }
-serde_json = "1.0.64"
+serde_json = "1.0"
 
 [features]
-default = []
+default = ["std"]
 fuzzing = ["proptest", "proptest-derive", "arbitrary", "move-core-types/fuzzing"]
+
+std = [
+    "anyhow/std",
+    "move-core-types/std",
+]

--- a/language/move-binary-format/src/access.rs
+++ b/language/move-binary-format/src/access.rs
@@ -5,6 +5,8 @@
 //! Defines accessors for compiled modules.
 
 use crate::{file_format::*, internals::ModuleIndex};
+use alloc::borrow::ToOwned;
+use alloc::vec::Vec;
 use move_core_types::{
     account_address::AccountAddress,
     identifier::{IdentStr, Identifier},

--- a/language/move-binary-format/src/binary_views.rs
+++ b/language/move-binary-format/src/binary_views.rs
@@ -17,6 +17,8 @@ use crate::{
     },
     CompiledModule,
 };
+use alloc::borrow::ToOwned;
+use alloc::vec::Vec;
 use move_core_types::{
     account_address::AccountAddress,
     identifier::{IdentStr, Identifier},

--- a/language/move-binary-format/src/compatibility.rs
+++ b/language/move-binary-format/src/compatibility.rs
@@ -2,7 +2,7 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::BTreeSet;
+use alloc::collections::BTreeSet;
 
 use crate::{
     errors::{PartialVMError, PartialVMResult},

--- a/language/move-binary-format/src/constant.rs
+++ b/language/move-binary-format/src/constant.rs
@@ -4,6 +4,7 @@
 
 use crate::file_format::{Constant, SignatureToken};
 
+use alloc::boxed::Box;
 use move_core_types::value::{MoveTypeLayout, MoveValue};
 
 fn sig_to_ty(sig: &SignatureToken) -> Option<MoveTypeLayout> {

--- a/language/move-binary-format/src/control_flow_graph.rs
+++ b/language/move-binary-format/src/control_flow_graph.rs
@@ -4,7 +4,9 @@
 
 //! This module defines the control-flow graph uses for bytecode verification.
 use crate::file_format::{Bytecode, CodeOffset};
-use std::collections::{btree_map::Entry, BTreeMap, BTreeSet};
+use alloc::boxed::Box;
+use alloc::collections::{btree_map::Entry, BTreeMap, BTreeSet};
+use alloc::vec::Vec;
 
 // BTree/Hash agnostic type wrappers
 type Map<K, V> = BTreeMap<K, V>;
@@ -65,6 +67,7 @@ pub struct VMControlFlowGraph {
     loop_heads: Map<BlockId, /* back edges */ Set<BlockId>>,
 }
 
+#[cfg(feature = "std")]
 impl BasicBlock {
     pub fn display(&self, entry: BlockId) {
         println!("+=======================+");
@@ -223,6 +226,7 @@ impl VMControlFlowGraph {
         }
     }
 
+    #[cfg(feature = "std")]
     pub fn display(&self) {
         for (entry, block) in &self.blocks {
             block.display(*entry);

--- a/language/move-binary-format/src/cursor.rs
+++ b/language/move-binary-format/src/cursor.rs
@@ -1,0 +1,156 @@
+//! A `Cursor` wraps an in-memory buffer and provides it with a stripped
+//! down version of the `std::io::Cursor`.
+
+use core::cmp;
+
+use anyhow::{Error, Result};
+
+/// A `Cursor` wraps an in-memory buffer and provides it with a stripped
+/// down version of the `std::io::Cursor`.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct Cursor<T>
+where
+    T: AsRef<[u8]>,
+{
+    inner: T,
+    pos: u64,
+}
+
+impl<T> Cursor<T>
+where
+    T: AsRef<[u8]>,
+{
+    /// Creates a new cursor wrapping the provided underlying in-memory buffer.
+    ///
+    /// Cursor initial position is `0` even if underlying buffer (e.g., `Vec`)
+    /// is not empty. So writing to cursor starts with overwriting `Vec`
+    /// content, not with appending to it.
+    pub fn new(inner: T) -> Cursor<T> {
+        Cursor { pos: 0, inner }
+    }
+
+    /// Gets a reference to the underlying value in this cursor.
+    pub fn get_ref(&self) -> &T {
+        &self.inner
+    }
+
+    /// Returns the current position of this cursor.
+    pub fn position(&self) -> u64 {
+        self.pos
+    }
+
+    /// Pull some bytes from this source into the specified buffer, returning
+    /// how many bytes were read.
+    pub fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
+        let source = self.fill_buf();
+        let amt = cmp::min(buf.len(), source.len());
+
+        if amt == 1 {
+            buf[0] = source[0];
+        } else {
+            buf[..amt].copy_from_slice(&source[..amt]);
+        }
+
+        self.pos += amt as u64;
+        Ok(amt)
+    }
+
+    /// Read the exact number of bytes required to fill `buf`.
+    ///
+    /// This function reads as many bytes as necessary to completely fill the
+    /// specified buffer `buf`.
+    pub fn read_exact(&mut self, buf: &mut [u8]) -> Result<()> {
+        let n = buf.len();
+        let source = self.fill_buf();
+
+        if buf.len() > source.len() {
+            return Err(Error::msg("Unexpected Eof failed to fill whole buffer"));
+        }
+
+        if buf.len() == 1 {
+            buf[0] = source[0];
+        } else {
+            buf.copy_from_slice(&source[..n]);
+        }
+
+        self.pos += n as u64;
+        Ok(())
+    }
+
+    fn fill_buf(&mut self) -> &[u8] {
+        let amt = cmp::min(self.pos, self.inner.as_ref().len() as u64);
+        &self.inner.as_ref()[(amt as usize)..]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Cursor;
+
+    #[test]
+    fn test_mem_reader() {
+        let mut reader = Cursor::new(vec![0, 1, 2, 3, 4, 5, 6, 7]);
+        let mut buf = [];
+        assert_eq!(reader.read(&mut buf).unwrap(), 0);
+        assert_eq!(reader.position(), 0);
+        let mut buf = [0];
+        assert_eq!(reader.read(&mut buf).unwrap(), 1);
+        assert_eq!(reader.position(), 1);
+        let b: &[_] = &[0];
+        assert_eq!(buf, b);
+        let mut buf = [0; 4];
+        assert_eq!(reader.read(&mut buf).unwrap(), 4);
+        assert_eq!(reader.position(), 5);
+        let b: &[_] = &[1, 2, 3, 4];
+        assert_eq!(buf, b);
+        assert_eq!(reader.read(&mut buf).unwrap(), 3);
+        let b: &[_] = &[5, 6, 7];
+        assert_eq!(&buf[..3], b);
+        assert_eq!(reader.read(&mut buf).unwrap(), 0);
+    }
+
+    #[test]
+    fn test_boxed_slice_reader() {
+        let mut reader = Cursor::new(vec![0, 1, 2, 3, 4, 5, 6, 7].into_boxed_slice());
+        let mut buf = [];
+        assert_eq!(reader.read(&mut buf).unwrap(), 0);
+        assert_eq!(reader.position(), 0);
+        let mut buf = [0];
+        assert_eq!(reader.read(&mut buf).unwrap(), 1);
+        assert_eq!(reader.position(), 1);
+        let b: &[_] = &[0];
+        assert_eq!(buf, b);
+        let mut buf = [0; 4];
+        assert_eq!(reader.read(&mut buf).unwrap(), 4);
+        assert_eq!(reader.position(), 5);
+        let b: &[_] = &[1, 2, 3, 4];
+        assert_eq!(buf, b);
+        assert_eq!(reader.read(&mut buf).unwrap(), 3);
+        let b: &[_] = &[5, 6, 7];
+        assert_eq!(&buf[..3], b);
+        assert_eq!(reader.read(&mut buf).unwrap(), 0);
+    }
+
+    #[test]
+    fn test_buf_reader() {
+        let in_buf = vec![0, 1, 2, 3, 4, 5, 6, 7];
+        let mut reader = Cursor::new(&in_buf[..]);
+        let mut buf = [];
+        assert_eq!(reader.read(&mut buf).unwrap(), 0);
+        assert_eq!(reader.position(), 0);
+        let mut buf = [0];
+        assert_eq!(reader.read(&mut buf).unwrap(), 1);
+        assert_eq!(reader.position(), 1);
+        let b: &[_] = &[0];
+        assert_eq!(buf, b);
+        let mut buf = [0; 4];
+        assert_eq!(reader.read(&mut buf).unwrap(), 4);
+        assert_eq!(reader.position(), 5);
+        let b: &[_] = &[1, 2, 3, 4];
+        assert_eq!(buf, b);
+        assert_eq!(reader.read(&mut buf).unwrap(), 3);
+        let b: &[_] = &[5, 6, 7];
+        assert_eq!(&buf[..3], b);
+        assert_eq!(reader.read(&mut buf).unwrap(), 0);
+    }
+}

--- a/language/move-binary-format/src/errors.rs
+++ b/language/move-binary-format/src/errors.rs
@@ -6,15 +6,18 @@ use crate::{
     file_format::{CodeOffset, FunctionDefinitionIndex, TableIndex},
     IndexKind,
 };
+use alloc::boxed::Box;
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::fmt;
 use move_core_types::{
     language_storage::ModuleId,
     vm_status::{self, StatusCode, StatusType, VMStatus},
 };
-use std::fmt;
 
-pub type VMResult<T> = ::std::result::Result<T, VMError>;
-pub type BinaryLoaderResult<T> = ::std::result::Result<T, PartialVMError>;
-pub type PartialVMResult<T> = ::std::result::Result<T, PartialVMError>;
+pub type VMResult<T> = core::result::Result<T, VMError>;
+pub type BinaryLoaderResult<T> = core::result::Result<T, PartialVMError>;
+pub type PartialVMResult<T> = core::result::Result<T, PartialVMError>;
 
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub enum Location {
@@ -242,7 +245,13 @@ impl fmt::Debug for VMError_ {
     }
 }
 
-impl std::error::Error for VMError {}
+pub trait Error: fmt::Debug + fmt::Display {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        None
+    }
+}
+
+impl Error for VMError {}
 
 #[derive(Clone)]
 pub struct PartialVMError(Box<PartialVMError_>);
@@ -525,8 +534,4 @@ impl fmt::Debug for PartialVMError_ {
     }
 }
 
-impl std::error::Error for PartialVMError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        None
-    }
-}
+impl Error for PartialVMError {}

--- a/language/move-binary-format/src/file_format.rs
+++ b/language/move-binary-format/src/file_format.rs
@@ -34,6 +34,11 @@ use crate::{
     internals::ModuleIndex,
     IndexKind, SignatureTokenKind,
 };
+use alloc::borrow::ToOwned;
+use alloc::boxed::Box;
+use alloc::string::ToString;
+use alloc::vec::Vec;
+use core::{fmt, ops::BitOr};
 use move_core_types::{
     account_address::AccountAddress,
     identifier::{IdentStr, Identifier},
@@ -45,7 +50,6 @@ use move_core_types::{
 use proptest::{collection::vec, prelude::*, strategy::BoxedStrategy};
 use ref_cast::RefCast;
 use serde::{Deserialize, Serialize};
-use std::ops::BitOr;
 use variant_count::VariantCount;
 
 /// Generic index into one of the tables in the binary format.
@@ -71,14 +75,14 @@ macro_rules! define_index {
             }
         }
 
-        impl ::std::fmt::Display for $name {
-            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        impl fmt::Display for $name {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 write!(f, "{}", self.0)
             }
         }
 
-        impl ::std::fmt::Debug for $name {
-            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        impl fmt::Debug for $name {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 write!(f, "{}({})", stringify!($name), self.0)
             }
         }
@@ -438,7 +442,7 @@ impl Default for Visibility {
     }
 }
 
-impl std::convert::TryFrom<u8> for Visibility {
+impl core::convert::TryFrom<u8> for Visibility {
     type Error = ();
 
     fn try_from(v: u8) -> Result<Self, Self::Error> {
@@ -807,8 +811,8 @@ impl IntoIterator for AbilitySet {
     }
 }
 
-impl std::fmt::Debug for AbilitySet {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+impl fmt::Debug for AbilitySet {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(f, "[")?;
         for ability in *self {
             write!(f, "{:?}, ", ability)?;
@@ -975,8 +979,8 @@ impl Arbitrary for SignatureToken {
     }
 }
 
-impl std::fmt::Debug for SignatureToken {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+impl fmt::Debug for SignatureToken {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             SignatureToken::Bool => write!(f, "Bool"),
             SignatureToken::U8 => write!(f, "U8"),
@@ -1637,8 +1641,8 @@ pub enum Bytecode {
     CastU256,
 }
 
-impl ::std::fmt::Debug for Bytecode {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+impl fmt::Debug for Bytecode {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Bytecode::Pop => write!(f, "Pop"),
             Bytecode::Ret => write!(f, "Ret"),

--- a/language/move-binary-format/src/file_format_common.rs
+++ b/language/move-binary-format/src/file_format_common.rs
@@ -11,12 +11,12 @@
 //! We use LEB128 for integer compression. LEB128 is a representation from the DWARF3 spec,
 //! http://dwarfstd.org/Dwarf3Std.php or https://en.wikipedia.org/wiki/LEB128.
 //! It's used to compress mostly indexes into the main binary tables.
+use crate::cursor::Cursor;
 use crate::file_format::Bytecode;
+use alloc::string::ToString;
+use alloc::vec::Vec;
 use anyhow::{bail, Result};
-use std::{
-    io::{Cursor, Read},
-    mem::size_of,
-};
+use core::mem::size_of;
 
 /// Constant values for the binary format header.
 ///
@@ -413,9 +413,9 @@ pub const VERSION_MAX: u32 = VERSION_6;
 pub const VERSION_MIN: u32 = VERSION_5;
 
 pub(crate) mod versioned_data {
+    use crate::cursor::Cursor;
     use crate::{errors::*, file_format_common::*};
     use move_core_types::vm_status::StatusCode;
-    use std::io::{Cursor, Read};
     pub struct VersionedBinary<'a> {
         version: u32,
         binary: &'a [u8],
@@ -533,11 +533,13 @@ pub(crate) mod versioned_data {
         pub fn new_for_test(version: u32, cursor: Cursor<&'a [u8]>) -> Self {
             Self { version, cursor }
         }
-    }
 
-    impl<'a> Read for VersionedCursor<'a> {
-        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        pub fn read(&mut self, buf: &mut [u8]) -> anyhow::Result<usize> {
             self.cursor.read(buf)
+        }
+
+        pub fn read_exact(&mut self, buf: &mut [u8]) -> Result<()> {
+            self.cursor.read_exact(buf)
         }
     }
 }

--- a/language/move-binary-format/src/lib.rs
+++ b/language/move-binary-format/src/lib.rs
@@ -3,13 +3,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]
+#![cfg_attr(not(feature = "std"), no_std)]
 
-use std::fmt;
+#[macro_use]
+extern crate alloc;
+
+use core::fmt;
 
 pub mod access;
 pub mod binary_views;
 pub mod check_bounds;
 pub mod compatibility;
+mod cursor;
 #[macro_use]
 pub mod errors;
 pub mod constant;

--- a/language/move-binary-format/src/normalized.rs
+++ b/language/move-binary-format/src/normalized.rs
@@ -10,13 +10,17 @@ use crate::{
         Visibility,
     },
 };
+use alloc::borrow::ToOwned;
+use alloc::boxed::Box;
+use alloc::collections::BTreeMap;
+use alloc::vec::Vec;
+use core::fmt;
 use move_core_types::{
     account_address::AccountAddress,
     identifier::{IdentStr, Identifier},
     language_storage::{ModuleId, StructTag, TypeTag},
 };
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
 
 /// Defines normalized representations of Move types, fields, kinds, structs, functions, and
 /// modules. These representations are useful in situations that require require comparing
@@ -378,8 +382,8 @@ impl From<TypeTag> for Type {
     }
 }
 
-impl std::fmt::Display for Type {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl fmt::Display for Type {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Type::Struct {
                 address,

--- a/language/move-binary-format/src/proptest_types.rs
+++ b/language/move-binary-format/src/proptest_types.rs
@@ -31,7 +31,9 @@ use crate::proptest_types::{
     signature::SignatureGen,
     types::{StDefnMaterializeState, StructDefinitionGen, StructHandleGen},
 };
-use std::collections::{BTreeSet, HashMap};
+use alloc::collections::BTreeSet;
+use alloc::vec::Vec;
+use hashbrown::HashMap;
 
 /// Represents how large [`CompiledModule`] tables can be.
 pub type TableSize = u16;

--- a/language/move-binary-format/src/proptest_types/constants.rs
+++ b/language/move-binary-format/src/proptest_types/constants.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::file_format::{Constant, SignatureToken};
+use alloc::vec::Vec;
 use move_core_types::account_address::AccountAddress;
 use proptest::{
     arbitrary::any,

--- a/language/move-binary-format/src/proptest_types/functions.rs
+++ b/language/move-binary-format/src/proptest_types/functions.rs
@@ -18,15 +18,15 @@ use crate::{
         TableSize,
     },
 };
+use alloc::collections::BTreeSet;
+use alloc::vec::Vec;
+use core::hash::Hash;
+use hashbrown::{HashMap, HashSet};
 use move_core_types::u256::U256;
 use proptest::{
     collection::{vec, SizeRange},
     prelude::*,
     sample::{select, Index as PropIndex},
-};
-use std::{
-    collections::{BTreeSet, HashMap, HashSet},
-    hash::Hash,
 };
 
 #[derive(Debug, Default)]

--- a/language/move-binary-format/src/proptest_types/metadata.rs
+++ b/language/move-binary-format/src/proptest_types/metadata.rs
@@ -2,6 +2,7 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use alloc::vec::Vec;
 use move_core_types::metadata::Metadata;
 use proptest::{
     arbitrary::any,

--- a/language/move-binary-format/src/proptest_types/signature.rs
+++ b/language/move-binary-format/src/proptest_types/signature.rs
@@ -6,6 +6,8 @@ use crate::file_format::{
     Ability, AbilitySet, Signature, SignatureToken, StructHandle, StructHandleIndex, TableIndex,
     TypeParameterIndex,
 };
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 use proptest::{
     collection::{vec, SizeRange},
     prelude::*,

--- a/language/move-binary-format/src/proptest_types/types.rs
+++ b/language/move-binary-format/src/proptest_types/types.rs
@@ -14,6 +14,8 @@ use crate::{
         signature::{AbilitySetGen, SignatureTokenGen},
     },
 };
+use alloc::collections::BTreeSet;
+use alloc::vec::Vec;
 use proptest::{
     collection::{vec, SizeRange},
     option,
@@ -21,7 +23,6 @@ use proptest::{
     sample::Index as PropIndex,
     std_facade::hash_set::HashSet,
 };
-use std::collections::BTreeSet;
 
 #[derive(Debug)]
 struct TypeSignatureIndex(u16);

--- a/language/move-binary-format/src/serializer.rs
+++ b/language/move-binary-format/src/serializer.rs
@@ -21,6 +21,8 @@ use move_core_types::{
     account_address::AccountAddress, identifier::Identifier, metadata::Metadata,
 };
 
+use alloc::vec::Vec;
+
 impl CompiledScript {
     /// Serializes a `CompiledScript` into a binary. The mutable `Vec<u8>` will contain the
     /// binary blob on return.

--- a/language/move-binary-format/src/unit_tests/number_tests.rs
+++ b/language/move-binary-format/src/unit_tests/number_tests.rs
@@ -2,9 +2,9 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::cursor::Cursor;
 use crate::file_format_common::*;
 use proptest::prelude::*;
-use std::io::{Cursor, Read};
 
 // verify all bytes in the vector have the high bit set except the last one
 fn check_vector(buf: &[u8]) {

--- a/language/move-binary-format/src/unit_tests/signature_token_tests.rs
+++ b/language/move-binary-format/src/unit_tests/signature_token_tests.rs
@@ -2,13 +2,13 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::cursor::Cursor;
 use crate::{
     deserializer::load_signature_token_test_entry,
     file_format::{SignatureToken, StructHandleIndex},
     file_format_common::{BinaryData, SerializedType, SIGNATURE_TOKEN_DEPTH_MAX},
     serializer::{serialize_signature_token, serialize_signature_token_unchecked},
 };
-use std::io::Cursor;
 
 #[test]
 fn serialize_and_deserialize_nested_types_max() {

--- a/language/move-binary-format/src/views.rs
+++ b/language/move-binary-format/src/views.rs
@@ -12,13 +12,15 @@
 //!   immediately -- the views are a convenience to make that simpler. They've been written as lazy
 //!   iterators to aid understanding of the file format and to make it easy to generate views.
 
-use std::iter::DoubleEndedIterator;
+use core::iter::DoubleEndedIterator;
 
 use crate::{access::ModuleAccess, file_format::*, SignatureTokenKind};
-use std::collections::BTreeSet;
+use alloc::collections::BTreeSet;
 
+use alloc::collections::BTreeMap;
 use move_core_types::{identifier::IdentStr, language_storage::ModuleId};
-use std::collections::BTreeMap;
+
+use alloc::vec::Vec;
 
 /// Represents a lazily evaluated abstraction over a module.
 ///


### PR DESCRIPTION
Two commits:
```
    feat(move-binary-format): no-std adaptation
```
```
    feat(move-binary-format): add custom Cursor impl

    `std::io::Cursor` will need replacement in no-std env,
    so a stripped-down version of it is needed.
```