### PR TITLE
    chore(move-core-types): fix tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1366,7 +1377,7 @@ dependencies = [
  "mirai-annotations",
  "once_cell",
  "proptest",
- "proptest-derive",
+ "proptest-derive 0.3.0",
  "rand 0.8.5",
  "rand_core 0.6.4",
  "ripemd160",
@@ -2254,7 +2265,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash",
+ "ahash 0.7.6",
 ]
 
 [[package]]
@@ -2262,6 +2273,9 @@ name = "hashbrown"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+dependencies = [
+ "ahash 0.8.3",
+]
 
 [[package]]
 name = "heck"
@@ -2607,7 +2621,7 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ab388864246d58a276e60e7569a833d9cc4cd75c66e5ca77c177dad38e59996"
 dependencies = [
- "ahash",
+ "ahash 0.7.6",
  "dashmap",
  "hashbrown 0.12.3",
  "once_cell",
@@ -3117,10 +3131,10 @@ version = "0.0.3"
 dependencies = [
  "anyhow",
  "arbitrary",
+ "hashbrown 0.14.0",
  "move-core-types",
- "once_cell",
  "proptest",
- "proptest-derive",
+ "proptest-derive 0.4.0",
  "ref-cast",
  "serde 1.0.188",
  "serde_json",
@@ -3293,19 +3307,22 @@ name = "move-core-types"
 version = "0.0.4"
 dependencies = [
  "anyhow",
+ "arbitrary",
  "bcs 0.1.4",
  "ethnum",
  "hashbrown 0.14.0",
  "hex",
  "num 0.4.1",
+ "once_cell",
  "primitive-types 0.12.1",
  "proptest",
- "proptest-derive",
+ "proptest-derive 0.4.0",
  "rand 0.8.5",
  "ref-cast",
  "regex",
  "serde 1.0.188",
  "serde_bytes",
+ "serde_json",
  "uint",
 ]
 
@@ -4886,6 +4903,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest-derive"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf16337405ca084e9c78985114633b6827711d22b9e6ef6c6c0d665eb3f0b6e"
+dependencies = [
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "prover-lab"
 version = "0.1.0"
 dependencies = [
@@ -5634,7 +5662,7 @@ version = "0.1.0"
 dependencies = [
  "move-binary-format",
  "proptest",
- "proptest-derive",
+ "proptest-derive 0.3.0",
 ]
 
 [[package]]

--- a/language/move-binary-format/Cargo.toml
+++ b/language/move-binary-format/Cargo.toml
@@ -17,8 +17,8 @@ ref-cast = "1.0"
 variant_count = "1.1"
 move-core-types = { path = "../move-core/types", default-features = false }
 serde = { version = "1.0", default-features = false }
-arbitrary = { version = "1.3", optional = true, features = ["derive"] }
-hashbrown = { version = "0.14", features = ["ahash"] }
+arbitrary = { version = "1.3", default-features = false, features = ["derive"], optional = true }
+hashbrown = { version = "0.14", default-features = false, features = ["ahash"] }
 
 [dev-dependencies]
 proptest = "1.0"

--- a/language/move-core/types/Cargo.toml
+++ b/language/move-core/types/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 anyhow = { version = "1.0", default-features = false }
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
 proptest = { version = "1.2", default-features = false, optional = true }
-proptest-derive = { version = "0.3", default-features = false, optional = true }
+proptest-derive = { version = "0.4", default-features = false, optional = true }
 rand = { version = "0.8", default-features = false }
 ref-cast = "1.0"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
@@ -21,20 +21,24 @@ serde_bytes = { version = "0.11", default-features = false, features = ["alloc"]
 primitive-types = { version = "0.12", default-features = false }
 uint = { version = "0.9", default-features = false }
 num = { version = "0.4", default-features = false, features = ["alloc"] }
-ethnum = { version = "1.3", default-features = false }
-hashbrown = { version = "0.14" , default-features = false }
+ethnum = { version = "1.4", default-features = false }
+hashbrown = { version = "0.14", default-features = false, features = ["ahash"] }
 bcs = { default-features = false, git = "https://github.com/eigerco/bcs.git", branch = "master"}
+arbitrary = { version = "1.3", default-features = false, features = ["derive_arbitrary"], optional = true }
 
 [dev-dependencies]
 proptest = "1.2"
-proptest-derive = "0.3"
+proptest-derive = "0.4"
 regex = "1.9"
+arbitrary = { version = "1.3", default-features = false, features = ["derive_arbitrary"] }
+serde_json = "1.0"
+once_cell = "1.18"
 
 [features]
 address20 = []
 address32 = []
 default = ["std", "address32"]
-fuzzing = ["proptest", "proptest-derive"]
+fuzzing = ["proptest", "proptest-derive", "arbitrary"]
 
 std = [
     "anyhow/std",

--- a/language/move-core/types/src/account_address.rs
+++ b/language/move-core/types/src/account_address.rs
@@ -51,7 +51,7 @@ impl AccountAddress {
         Self(addr)
     }
 
-    #[cfg(featire = "std")]
+    #[cfg(feature = "std")]
     pub fn random() -> Self {
         use rand::{rngs::OsRng, Rng};
         let mut rng = OsRng;
@@ -324,8 +324,8 @@ mod tests {
 
     #[test]
     fn test_display_impls() {
-        let hex = "ca843279e3427144cead5e4d5999a3d0";
-        let upper_hex = "CA843279E3427144CEAD5E4D5999A3D0";
+        let hex = "ca843279e3427144cead5e4d5999a3d0ca843279e3427144cead5e4d5999a3d0";
+        let upper_hex = "CA843279E3427144CEAD5E4D5999A3D0CA843279E3427144CEAD5E4D5999A3D0";
 
         let address = AccountAddress::from_hex(hex).unwrap();
 
@@ -340,24 +340,24 @@ mod tests {
 
     #[test]
     fn test_short_str_lossless() {
-        let address = AccountAddress::from_hex("00c0f1f95c5b1c5f0eda533eff269000").unwrap();
+        let address = AccountAddress::from_hex("00c0f1f95c5b1c5f0eda533eff26900000c0f1f95c5b1c5f0eda533eff269000").unwrap();
 
         assert_eq!(
             address.short_str_lossless(),
-            "c0f1f95c5b1c5f0eda533eff269000",
+            "c0f1f95c5b1c5f0eda533eff26900000c0f1f95c5b1c5f0eda533eff269000",
         );
     }
 
     #[test]
     fn test_short_str_lossless_zero() {
-        let address = AccountAddress::from_hex("00000000000000000000000000000000").unwrap();
+        let address = AccountAddress::from_hex("0000000000000000000000000000000000000000000000000000000000000000").unwrap();
 
         assert_eq!(address.short_str_lossless(), "0");
     }
 
     #[test]
     fn test_address() {
-        let hex = "ca843279e3427144cead5e4d5999a3d0";
+        let hex = "ca843279e3427144cead5e4d5999a3d0ca843279e3427144cead5e4d5999a3d0";
         let bytes = Vec::from_hex(hex).expect("You must provide a valid Hex format");
 
         assert_eq!(
@@ -377,7 +377,7 @@ mod tests {
     #[test]
     fn test_from_hex_literal() {
         let hex_literal = "0x1";
-        let hex = "00000000000000000000000000000001";
+        let hex = "0000000000000000000000000000000000000000000000000000000000000001";
 
         let address_from_literal = AccountAddress::from_hex_literal(hex_literal).unwrap();
         let address = AccountAddress::from_hex(hex).unwrap();
@@ -388,7 +388,7 @@ mod tests {
         // Missing '0x'
         AccountAddress::from_hex_literal(hex).unwrap_err();
         // Too long
-        AccountAddress::from_hex_literal("0x100000000000000000000000000000001").unwrap_err();
+        AccountAddress::from_hex_literal("0x10000000000000000000000000000000000000000000000000000000000000001").unwrap_err();
     }
 
     #[test]
@@ -414,8 +414,8 @@ mod tests {
 
     #[test]
     fn test_serde_json() {
-        let hex = "ca843279e3427144cead5e4d5999a3d0";
-        let json_hex = "\"ca843279e3427144cead5e4d5999a3d0\"";
+        let hex = "ca843279e3427144cead5e4d5999a3d0ca843279e3427144cead5e4d5999a3d0";
+        let json_hex = "\"ca843279e3427144cead5e4d5999a3d0ca843279e3427144cead5e4d5999a3d0\"";
 
         let address = AccountAddress::from_hex(hex).unwrap();
 

--- a/language/move-core/types/src/errmap.rs
+++ b/language/move-core/types/src/errmap.rs
@@ -1,12 +1,11 @@
 // Copyright (c) The Diem Core Contributors
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
-// TODO: Remove this file possibly, currently mod unused
 
 use crate::language_storage::ModuleId;
 use anyhow::{bail, Result};
 use serde::{Deserialize, Serialize};
-use sp_std::{
+use std::{
     fs::File,
     io::{Read, Write},
     path::Path,

--- a/language/move-core/types/src/lib.rs
+++ b/language/move-core/types/src/lib.rs
@@ -12,9 +12,9 @@ extern crate alloc;
 pub mod abi;
 pub mod account_address;
 pub mod effects;
-// Uses too much IO operations, and doesn't seem to be very important for the runtime, commenting
-// it out for now:
-//pub mod errmap;
+// Not needed for pallet-move and no-std env
+#[cfg(feature = "std")]
+pub mod errmap;
 pub mod gas_algebra;
 pub mod identifier;
 pub mod language_storage;
@@ -24,6 +24,8 @@ pub mod parser;
 #[cfg(any(test, feature = "fuzzing"))]
 pub mod proptest_types;
 pub mod resolver;
+// Not needed for pallet-move and no-std env
+#[cfg(feature = "std")]
 pub mod state;
 pub mod transaction_argument;
 pub mod u256;

--- a/language/move-core/types/src/state.rs
+++ b/language/move-core/types/src/state.rs
@@ -2,6 +2,8 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use std::cell::RefCell;
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum VMState {
     DESERIALIZER,
@@ -10,17 +12,14 @@ pub enum VMState {
     OTHER,
 }
 
-// Small TODO: We should be safe here in a single-threaded wasm environment - but we might
-// need to use RefCell for move-compiler though
-static mut STATE: VMState = VMState::OTHER;
+thread_local! {
+    static STATE: RefCell<VMState> = RefCell::new(VMState::OTHER);
+}
 
 pub fn set_state(state: VMState) -> VMState {
-    unsafe {
-        STATE = state;
-    }
-    state
+    STATE.with(|s| s.replace(state))
 }
 
 pub fn get_state() -> VMState {
-    unsafe { STATE }
+    STATE.with(|s| *s.borrow())
 }


### PR DESCRIPTION
With this PR, all tests are now passing in both `move-core-types` and `move-binary-format`.
Some commented parts of `move-core-types` are uncommented and feature-gated instead.

```
    chore(move-core-types): fix tests
```
```
    chore(move-core-types): gate files required for toolchain

    Some files are not required for the pallet-move and no-std environment
```