### PR TITLE
feat: make move-vm-types package no_std compatible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3964,10 +3964,9 @@ dependencies = [
 name = "move-vm-types"
 version = "0.1.0"
 dependencies = [
- "bcs 0.1.5",
+ "bcs 0.1.4",
  "move-binary-format",
  "move-core-types",
- "once_cell",
  "proptest",
  "serde 1.0.188",
  "smallvec",

--- a/language/move-core/types/Cargo.toml
+++ b/language/move-core/types/Cargo.toml
@@ -23,7 +23,7 @@ uint = { version = "0.9", default-features = false }
 num = { version = "0.4", default-features = false, features = ["alloc"] }
 ethnum = { version = "1.4", default-features = false }
 hashbrown = { version = "0.14", default-features = false, features = ["ahash"] }
-bcs = { default-features = false, git = "https://github.com/eigerco/bcs.git", branch = "master"}
+bcs = { default-features = false, git = "https://github.com/eigerco/bcs.git", branch = "master" }
 arbitrary = { version = "1.3", default-features = false, features = ["derive_arbitrary"], optional = true }
 
 [dev-dependencies]

--- a/language/move-vm/types/Cargo.toml
+++ b/language/move-vm/types/Cargo.toml
@@ -14,9 +14,9 @@ proptest = { version = "1.2", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive", "rc"] }
 smallvec = { version = "1.11", default-features = false }
 
-bcs = { default-features = false, git = "https://github.com/eigerco/bcs.git", branch = "master"}
+bcs = { default-features = false, git = "https://github.com/eigerco/bcs.git", branch = "master" }
 
-move-core-types = { path = "../../move-core/types", default-features = false}
+move-core-types = { path = "../../move-core/types", default-features = false }
 move-binary-format = { path = "../../move-binary-format", default-features = false }
 
 [dev-dependencies]

--- a/language/move-vm/types/Cargo.toml
+++ b/language/move-vm/types/Cargo.toml
@@ -10,19 +10,24 @@ publish = false
 edition = "2021"
 
 [dependencies]
-once_cell = "1.7.2"
-proptest = { version = "1.0.0", optional = true }
-serde = { version = "1.0.124", features = ["derive", "rc"] }
-smallvec = "1.6.1"
+proptest = { version = "1.2", default-features = false, optional = true }
+serde = { version = "1.0", default-features = false, features = ["derive", "rc"] }
+smallvec = { version = "1.11", default-features = false }
 
-bcs.workspace = true
+bcs = { default-features = false, git = "https://github.com/eigerco/bcs.git", branch = "master"}
 
-move-core-types = { path = "../../move-core/types" }
-move-binary-format = { path = "../../move-binary-format" }
+move-core-types = { path = "../../move-core/types", default-features = false}
+move-binary-format = { path = "../../move-binary-format", default-features = false }
 
 [dev-dependencies]
-proptest = "1.0.0"
+proptest = "1.2"
 
 [features]
-default = []
+default = ["std"]
 fuzzing = ["proptest", "move-binary-format/fuzzing"]
+
+std = [
+    "move-core-types/std",
+    "move-binary-format/std",
+    "bcs/std",
+]

--- a/language/move-vm/types/src/data_store.rs
+++ b/language/move-vm/types/src/data_store.rs
@@ -12,6 +12,8 @@ use move_core_types::{
     value::MoveTypeLayout,
 };
 
+use alloc::vec::Vec;
+
 /// Provide an implementation for bytecodes related to data with a given data store.
 ///
 /// The `DataStore` is a generic concept that includes both data and events.

--- a/language/move-vm/types/src/lib.rs
+++ b/language/move-vm/types/src/lib.rs
@@ -2,7 +2,11 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![cfg_attr(not(feature = "std"), no_std)]
 #![forbid(unsafe_code)]
+
+#[macro_use]
+extern crate alloc;
 
 macro_rules! debug_write {
     ($($toks: tt)*) => {

--- a/language/move-vm/types/src/loaded_data/runtime_types.rs
+++ b/language/move-vm/types/src/loaded_data/runtime_types.rs
@@ -12,7 +12,12 @@ use move_core_types::{
     gas_algebra::AbstractMemorySize, identifier::Identifier, language_storage::ModuleId,
     vm_status::StatusCode,
 };
-use std::{cmp::max, collections::BTreeMap, fmt::Debug};
+
+use alloc::boxed::Box;
+use alloc::collections::BTreeMap;
+use alloc::string::ToString;
+use alloc::vec::Vec;
+use core::{cmp::max, fmt::Debug};
 
 pub const TYPE_DEPTH_MAX: usize = 256;
 

--- a/language/move-vm/types/src/values/value_tests.rs
+++ b/language/move-vm/types/src/values/value_tests.rs
@@ -6,6 +6,8 @@ use crate::{loaded_data::runtime_types::Type, values::*, views::*};
 use move_binary_format::errors::*;
 use move_core_types::{account_address::AccountAddress, u256::U256};
 
+use alloc::vec::Vec;
+
 #[test]
 fn locals() -> PartialVMResult<()> {
     const LEN: usize = 4;

--- a/language/move-vm/types/src/values/values_impl.rs
+++ b/language/move-vm/types/src/values/values_impl.rs
@@ -18,11 +18,16 @@ use move_core_types::{
     value::{MoveStructLayout, MoveTypeLayout},
     vm_status::{sub_status::NFE_VECTOR_ERROR_BASE, StatusCode},
 };
-use std::{
+
+use alloc::boxed::Box;
+use alloc::rc::Rc;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+
+use core::{
     cell::RefCell,
     fmt::{self, Debug, Display},
     iter,
-    rc::Rc,
 };
 
 /***************************************************************************************
@@ -1007,7 +1012,7 @@ impl Locals {
                         .with_message("moving container with dangling references".to_string()));
                     }
                 }
-                Ok(Value(std::mem::replace(v, x.0)))
+                Ok(Value(core::mem::replace(v, x.0)))
             }
             None => Err(
                 PartialVMError::new(StatusCode::VERIFIER_INVARIANT_VIOLATION).with_message(
@@ -1046,7 +1051,7 @@ impl Locals {
                 }
                 _ => res.push((
                     idx,
-                    Value(std::mem::replace(&mut locals[idx], ValueImpl::Invalid)),
+                    Value(core::mem::replace(&mut locals[idx], ValueImpl::Invalid)),
                 )),
             }
         }
@@ -1752,7 +1757,7 @@ impl IntegerValue {
         match self {
             U8(x) => Ok(x),
             U16(x) => {
-                if x > (std::u8::MAX as u16) {
+                if x > (u8::MAX as u16) {
                     Err(PartialVMError::new(StatusCode::ARITHMETIC_ERROR)
                         .with_message(format!("Cannot cast u16({}) to u8", x)))
                 } else {
@@ -1760,7 +1765,7 @@ impl IntegerValue {
                 }
             }
             U32(x) => {
-                if x > (std::u8::MAX as u32) {
+                if x > (u8::MAX as u32) {
                     Err(PartialVMError::new(StatusCode::ARITHMETIC_ERROR)
                         .with_message(format!("Cannot cast u32({}) to u8", x)))
                 } else {
@@ -1768,7 +1773,7 @@ impl IntegerValue {
                 }
             }
             U64(x) => {
-                if x > (std::u8::MAX as u64) {
+                if x > (u8::MAX as u64) {
                     Err(PartialVMError::new(StatusCode::ARITHMETIC_ERROR)
                         .with_message(format!("Cannot cast u64({}) to u8", x)))
                 } else {
@@ -1776,7 +1781,7 @@ impl IntegerValue {
                 }
             }
             U128(x) => {
-                if x > (std::u8::MAX as u128) {
+                if x > (u8::MAX as u128) {
                     Err(PartialVMError::new(StatusCode::ARITHMETIC_ERROR)
                         .with_message(format!("Cannot cast u128({}) to u8", x)))
                 } else {
@@ -1784,7 +1789,7 @@ impl IntegerValue {
                 }
             }
             U256(x) => {
-                if x > (u256::U256::from(std::u8::MAX)) {
+                if x > (u256::U256::from(u8::MAX)) {
                     Err(PartialVMError::new(StatusCode::ARITHMETIC_ERROR)
                         .with_message(format!("Cannot cast u256({}) to u8", x)))
                 } else {
@@ -1801,7 +1806,7 @@ impl IntegerValue {
             U8(x) => Ok(x as u16),
             U16(x) => Ok(x),
             U32(x) => {
-                if x > (std::u16::MAX as u32) {
+                if x > (u16::MAX as u32) {
                     Err(PartialVMError::new(StatusCode::ARITHMETIC_ERROR)
                         .with_message(format!("Cannot cast u32({}) to u16", x)))
                 } else {
@@ -1809,7 +1814,7 @@ impl IntegerValue {
                 }
             }
             U64(x) => {
-                if x > (std::u16::MAX as u64) {
+                if x > (u16::MAX as u64) {
                     Err(PartialVMError::new(StatusCode::ARITHMETIC_ERROR)
                         .with_message(format!("Cannot cast u64({}) to u16", x)))
                 } else {
@@ -1817,7 +1822,7 @@ impl IntegerValue {
                 }
             }
             U128(x) => {
-                if x > (std::u16::MAX as u128) {
+                if x > (u16::MAX as u128) {
                     Err(PartialVMError::new(StatusCode::ARITHMETIC_ERROR)
                         .with_message(format!("Cannot cast u128({}) to u16", x)))
                 } else {
@@ -1825,7 +1830,7 @@ impl IntegerValue {
                 }
             }
             U256(x) => {
-                if x > (u256::U256::from(std::u16::MAX)) {
+                if x > (u256::U256::from(u16::MAX)) {
                     Err(PartialVMError::new(StatusCode::ARITHMETIC_ERROR)
                         .with_message(format!("Cannot cast u256({}) to u16", x)))
                 } else {
@@ -1843,7 +1848,7 @@ impl IntegerValue {
             U16(x) => Ok(x as u32),
             U32(x) => Ok(x),
             U64(x) => {
-                if x > (std::u32::MAX as u64) {
+                if x > (u32::MAX as u64) {
                     Err(PartialVMError::new(StatusCode::ARITHMETIC_ERROR)
                         .with_message(format!("Cannot cast u64({}) to u32", x)))
                 } else {
@@ -1851,7 +1856,7 @@ impl IntegerValue {
                 }
             }
             U128(x) => {
-                if x > (std::u32::MAX as u128) {
+                if x > (u32::MAX as u128) {
                     Err(PartialVMError::new(StatusCode::ARITHMETIC_ERROR)
                         .with_message(format!("Cannot cast u128({}) to u32", x)))
                 } else {
@@ -1859,7 +1864,7 @@ impl IntegerValue {
                 }
             }
             U256(x) => {
-                if x > (u256::U256::from(std::u32::MAX)) {
+                if x > (u256::U256::from(u32::MAX)) {
                     Err(PartialVMError::new(StatusCode::ARITHMETIC_ERROR)
                         .with_message(format!("Cannot cast u128({}) to u32", x)))
                 } else {
@@ -1878,7 +1883,7 @@ impl IntegerValue {
             U32(x) => Ok(x as u64),
             U64(x) => Ok(x),
             U128(x) => {
-                if x > (std::u64::MAX as u128) {
+                if x > (u64::MAX as u128) {
                     Err(PartialVMError::new(StatusCode::ARITHMETIC_ERROR)
                         .with_message(format!("Cannot cast u128({}) to u64", x)))
                 } else {
@@ -1886,7 +1891,7 @@ impl IntegerValue {
                 }
             }
             U256(x) => {
-                if x > (u256::U256::from(std::u64::MAX)) {
+                if x > (u256::U256::from(u64::MAX)) {
                     Err(PartialVMError::new(StatusCode::ARITHMETIC_ERROR)
                         .with_message(format!("Cannot cast u256({}) to u64", x)))
                 } else {
@@ -1906,7 +1911,7 @@ impl IntegerValue {
             U64(x) => Ok(x as u128),
             U128(x) => Ok(x),
             U256(x) => {
-                if x > (u256::U256::from(std::u128::MAX)) {
+                if x > (u256::U256::from(u128::MAX)) {
                     Err(PartialVMError::new(StatusCode::ARITHMETIC_ERROR)
                         .with_message(format!("Cannot cast u256({}) to u128", x)))
                 } else {
@@ -2038,7 +2043,7 @@ impl VectorRef {
     }
 
     /// Returns a RefCell reference to the underlying vector of a `&vector<u8>` value.
-    pub fn as_bytes_ref(&self) -> std::cell::Ref<'_, Vec<u8>> {
+    pub fn as_bytes_ref(&self) -> core::cell::Ref<'_, Vec<u8>> {
         let c = self.0.container();
         match c {
             Container::VecU8(r) => r.borrow(),
@@ -2300,28 +2305,28 @@ impl Container {
                 Struct::legacy_size_impl(&r.borrow())
             }
             Self::VecU8(r) => {
-                AbstractMemorySize::new((r.borrow().len() * std::mem::size_of::<u8>()) as u64)
+                AbstractMemorySize::new((r.borrow().len() * core::mem::size_of::<u8>()) as u64)
             }
             Self::VecU16(r) => {
-                AbstractMemorySize::new((r.borrow().len() * std::mem::size_of::<u16>()) as u64)
+                AbstractMemorySize::new((r.borrow().len() * core::mem::size_of::<u16>()) as u64)
             }
             Self::VecU32(r) => {
-                AbstractMemorySize::new((r.borrow().len() * std::mem::size_of::<u32>()) as u64)
+                AbstractMemorySize::new((r.borrow().len() * core::mem::size_of::<u32>()) as u64)
             }
             Self::VecU64(r) => {
-                AbstractMemorySize::new((r.borrow().len() * std::mem::size_of::<u64>()) as u64)
+                AbstractMemorySize::new((r.borrow().len() * core::mem::size_of::<u64>()) as u64)
             }
             Self::VecU128(r) => {
-                AbstractMemorySize::new((r.borrow().len() * std::mem::size_of::<u128>()) as u64)
+                AbstractMemorySize::new((r.borrow().len() * core::mem::size_of::<u128>()) as u64)
             }
             Self::VecU256(r) => AbstractMemorySize::new(
-                (r.borrow().len() * std::mem::size_of::<u256::U256>()) as u64,
+                (r.borrow().len() * core::mem::size_of::<u256::U256>()) as u64,
             ),
             Self::VecBool(r) => {
-                AbstractMemorySize::new((r.borrow().len() * std::mem::size_of::<bool>()) as u64)
+                AbstractMemorySize::new((r.borrow().len() * core::mem::size_of::<bool>()) as u64)
             }
             Self::VecAddress(r) => AbstractMemorySize::new(
-                (r.borrow().len() * std::mem::size_of::<AccountAddress>()) as u64,
+                (r.borrow().len() * core::mem::size_of::<AccountAddress>()) as u64,
             ),
         }
     }
@@ -2460,11 +2465,11 @@ impl GlobalValueImpl {
             Self::None | Self::Deleted => {
                 return Err(PartialVMError::new(StatusCode::MISSING_DATA))
             }
-            Self::Fresh { .. } => match std::mem::replace(self, Self::None) {
+            Self::Fresh { .. } => match core::mem::replace(self, Self::None) {
                 Self::Fresh { fields } => fields,
                 _ => unreachable!(),
             },
-            Self::Cached { .. } => match std::mem::replace(self, Self::Deleted) {
+            Self::Cached { .. } => match core::mem::replace(self, Self::Deleted) {
                 Self::Cached { fields, .. } => fields,
                 _ => unreachable!(),
             },
@@ -2719,7 +2724,7 @@ impl Display for Locals {
 #[allow(dead_code)]
 pub mod debug {
     use super::*;
-    use std::fmt::Write;
+    use core::fmt::Write;
 
     fn print_invalid<B: Write>(buf: &mut B) -> PartialVMResult<()> {
         debug_write!(buf, "-")

--- a/language/move-vm/types/src/views.rs
+++ b/language/move-vm/types/src/views.rs
@@ -1,10 +1,10 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use core::mem::size_of;
 use move_core_types::{
     account_address::AccountAddress, gas_algebra::AbstractMemorySize, language_storage::TypeTag,
 };
-use std::mem::size_of;
 
 /// Trait that provides an abstract view into a Move type.
 ///


### PR DESCRIPTION
no_std support has been added to the `move-vm-types` package.
The crate can now be compiled inside the WASM environment.
All tests are passing.