### PR TITLE
chore: fixes for move-cli

### DIFF
--- a/language/move-binary-format/src/errors.rs
+++ b/language/move-binary-format/src/errors.rs
@@ -245,13 +245,18 @@ impl fmt::Debug for VMError_ {
     }
 }
 
+#[cfg(not(feature = "std"))]
 pub trait Error: fmt::Debug + fmt::Display {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         None
     }
 }
 
+#[cfg(not(feature = "std"))]
 impl Error for VMError {}
+
+#[cfg(feature = "std")]
+impl std::error::Error for VMError {}
 
 #[derive(Clone)]
 pub struct PartialVMError(Box<PartialVMError_>);
@@ -534,4 +539,13 @@ impl fmt::Debug for PartialVMError_ {
     }
 }
 
+
+#[cfg(feature = "std")]
+impl std::error::Error for PartialVMError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        None
+    }
+}
+
+#[cfg(not(feature = "std"))]
 impl Error for PartialVMError {}

--- a/language/move-core/types/src/account_address.rs
+++ b/language/move-core/types/src/account_address.rs
@@ -304,12 +304,17 @@ impl fmt::Display for AccountAddressParseError {
     }
 }
 
+#[cfg(feature = "std")]
+impl std::error::Error for AccountAddressParseError {}
+
+#[cfg(not(feature = "std"))]
 pub trait Error: fmt::Debug + fmt::Display {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         None
     }
 }
 
+#[cfg(not(feature = "std"))]
 impl Error for AccountAddressParseError {}
 
 #[cfg(test)]

--- a/language/move-core/types/src/errmap.rs
+++ b/language/move-core/types/src/errmap.rs
@@ -6,13 +6,11 @@ use crate::language_storage::ModuleId;
 use anyhow::{bail, Result};
 use serde::{Deserialize, Serialize};
 use std::{
+    collections::BTreeMap,
     fs::File,
     io::{Read, Write},
     path::Path,
 };
-use alloc::vec::Vec;
-use alloc::string::String;
-use alloc::collections::btree_map::BTreeMap;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ErrorDescription {

--- a/language/move-core/types/src/u256.rs
+++ b/language/move-core/types/src/u256.rs
@@ -68,12 +68,17 @@ impl U256CastError {
     }
 }
 
+#[cfg(feature = "std")]
+impl std::error::Error for U256CastError {}
+
+#[cfg(not(feature = "std"))]
 pub trait Error: fmt::Debug + fmt::Display {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         None
     }
 }
 
+#[cfg(not(feature = "std"))]
 impl Error for U256CastError {}
 
 impl fmt::Display for U256CastError {
@@ -90,6 +95,14 @@ impl fmt::Display for U256CastError {
     }
 }
 
+#[cfg(feature = "std")]
+impl std::error::Error for U256FromStrError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.0.source()
+    }
+}
+
+#[cfg(not(feature = "std"))]
 impl Error for U256FromStrError {}
 
 impl fmt::Display for U256FromStrError {

--- a/language/move-core/types/src/vm_status.rs
+++ b/language/move-core/types/src/vm_status.rs
@@ -327,12 +327,17 @@ impl fmt::Debug for AbortLocation {
     }
 }
 
+#[cfg(feature = "std")]
+impl std::error::Error for VMStatus {}
+
+#[cfg(not(feature = "std"))]
 pub trait Error: fmt::Debug + fmt::Display {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         None
     }
 }
 
+#[cfg(not(feature = "std"))]
 impl Error for VMStatus {}
 
 macro_rules! derive_status_try_from_repr {

--- a/language/move-stdlib/Cargo.toml
+++ b/language/move-stdlib/Cargo.toml
@@ -37,6 +37,6 @@ move-cli = { path = "../tools/move-cli" }
 move-package = { path = "../tools/move-package" }
 
 [features]
-testing = []
+testing = ["move-core-types/address32"]
 address20 = ["move-core-types/address20"]
 address32 = ["move-core-types/address32"]


### PR DESCRIPTION
`move-cli`, `move-disassembler` can be compiled again.

The tests for `move-cli` are still failing, though. That'll be addressed in a separate PR.