### PR TITLE
ci: run tests on push action

### DIFF
--- a/.github/workflows/check-move-packages-pull-request.yml
+++ b/.github/workflows/check-move-packages-pull-request.yml
@@ -1,9 +1,6 @@
 name: Build Move crates
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main
@@ -11,7 +8,8 @@ on:
       - language/**
       - Cargo.toml
       - Cargo.lock
-      - .github/workflows/check-move-packages.yml
+      - .github/workflows/check-move-packages-pull-request.yml
+      - .github/workflows/check-move-packages-push.yml
       - move-vm-backend/**
 
 env:
@@ -39,11 +37,6 @@ jobs:
 
       - name: Run move-vm-runtime tests
         run: cargo test -p move-vm-runtime
-
-      # move-compiler
-
-      - name: Run move-compiler tests
-        run: cargo test -p move-compiler
 
       # move-cli
 

--- a/.github/workflows/check-move-packages-push.yml
+++ b/.github/workflows/check-move-packages-push.yml
@@ -1,0 +1,34 @@
+name: Build Move crates
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - language/**
+      - Cargo.toml
+      - Cargo.lock
+      - .github/workflows/check-move-packages-pull-request.yml
+      - .github/workflows/check-move-packages-push.yml
+      - move-vm-backend/**
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  check-move-packages:
+    runs-on: ubuntu-latest
+    name: Run all tests (except for move-compiler, move-cli, move-vm-runtime)
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+
+      - uses: ./.github/actions/build-setup
+
+      - name: Run all tests
+        run: cargo test


### PR DESCRIPTION
Updates:
- run full test suite when a commit is merged.
- skip running `move-compiler` tests on pull_request action.