### PR TITLE
deps: update petgraph to use no-std

### DIFF
--- a/language/move-bytecode-verifier/Cargo.toml
+++ b/language/move-bytecode-verifier/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = { version = "1.0", default-features = false }
-petgraph = "0.5"
+petgraph = { git = "https://github.com/eigerco/petgraph.git", branch = "master", default-features = false, features = ["graphmap"] }
 fail = { version = "0.5", default-features = false, optional = true }
 hashbrown = { version = "0.14", default-features = false, features = ["ahash"] }
 
@@ -32,4 +32,5 @@ std = [
     "move-borrow-graph/std",
     "move-binary-format/std",
     "move-core-types/std",
+    "petgraph/std",
 ]


### PR DESCRIPTION
Use the forked petgraph repo which is no-std compatible.