### PR TITLE
feat: running VM with publishing modules feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3884,6 +3884,14 @@ dependencies = [
 [[package]]
 name = "move-vm-backend"
 version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "move-binary-format",
+ "move-core-types",
+ "move-stdlib",
+ "move-vm-runtime",
+ "move-vm-types",
+]
 
 [[package]]
 name = "move-vm-integration-tests"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -440,6 +440,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "better_any"
+version = "0.2.0"
+source = "git+https://github.com/aj3n/better_any.git?branch=main#1cb28c24b8d0b66b33a42360492c32793b79f1d4"
+
+[[package]]
 name = "better_typeid_derive"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1329,7 +1334,7 @@ dependencies = [
  "guppy",
  "itertools",
  "once_cell",
- "petgraph 0.6.4",
+ "petgraph 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon",
  "serde 1.0.188",
  "toml",
@@ -2191,7 +2196,7 @@ dependencies = [
  "nested",
  "once_cell",
  "pathdiff",
- "petgraph 0.6.4",
+ "petgraph 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon",
  "semver",
  "serde 1.0.188",
@@ -2764,7 +2769,7 @@ dependencies = [
  "is-terminal",
  "itertools",
  "lalrpop-util",
- "petgraph 0.6.4",
+ "petgraph 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex",
  "regex-syntax 0.6.29",
  "string_cache",
@@ -3110,7 +3115,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bcs 0.1.5",
- "better_any",
+ "better_any 0.1.1",
  "datatest-stable",
  "itertools",
  "move-binary-format",
@@ -3184,7 +3189,7 @@ dependencies = [
  "move-binary-format",
  "move-borrow-graph",
  "move-core-types",
- "petgraph 0.5.1",
+ "petgraph 0.6.4 (git+https://github.com/eigerco/petgraph.git?branch=master)",
 ]
 
 [[package]]
@@ -3754,7 +3759,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bcs 0.1.5",
- "better_any",
+ "better_any 0.1.1",
  "move-binary-format",
  "move-cli",
  "move-core-types",
@@ -3850,7 +3855,7 @@ name = "move-unit-test"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "better_any",
+ "better_any 0.1.1",
  "clap 3.2.25",
  "codespan-reporting",
  "colored",
@@ -3925,7 +3930,7 @@ dependencies = [
 name = "move-vm-runtime"
 version = "0.1.0"
 dependencies = [
- "better_any",
+ "better_any 0.2.0",
  "fail 0.5.1",
  "hashbrown 0.14.0",
  "move-binary-format",
@@ -4585,6 +4590,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "petgraph"
+version = "0.6.4"
+source = "git+https://github.com/eigerco/petgraph.git?branch=master#1d8299983104e293b5343b930bb086e6b49b2d85"
+dependencies = [
+ "fixedbitset 0.4.2",
+ "hashbrown 0.14.0",
+ "indexmap 2.0.0",
+]
+
+[[package]]
 name = "phf"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4977,7 +4992,7 @@ dependencies = [
  "atty",
  "config",
  "directories",
- "petgraph 0.6.4",
+ "petgraph 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.188",
  "serde-value",
  "tint",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3890,6 +3890,7 @@ dependencies = [
  "move-core-types",
  "move-stdlib",
  "move-vm-runtime",
+ "move-vm-test-utils",
  "move-vm-types",
 ]
 

--- a/language/move-vm/runtime/Cargo.toml
+++ b/language/move-vm/runtime/Cargo.toml
@@ -24,8 +24,6 @@ move-core-types = { path = "../../move-core/types", default-features = false }
 move-vm-types = { path = "../types", default-features = false }
 move-binary-format = { path = "../../move-binary-format", default-features = false }
 
-better_any = { git = "https://github.com/aj3n/better_any.git", branch = "main", default-features = false }
-
 [features]
 default = ["std"]
 fuzzing = ["move-vm-types/fuzzing"]

--- a/language/move-vm/runtime/Cargo.toml
+++ b/language/move-vm/runtime/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 [dependencies]
 fail = { version = "0.5", default-features = false, optional = true }
 # v0.2 breaks the test build
-better_any = { version = "=0.1", default-features = false }
+# better_any = { version = "=0.1", default-features = false }
 sha3 = { version = "0.10", default-features = false }
 tracing = { version = "0.1", default-features = false }
 hashbrown = { version = "0.14", default-features = false, features = ["ahash"] }
@@ -24,6 +24,8 @@ move-bytecode-verifier = { path = "../../move-bytecode-verifier", default-featur
 move-core-types = { path = "../../move-core/types", default-features = false }
 move-vm-types = { path = "../types", default-features = false }
 move-binary-format = { path = "../../move-binary-format", default-features = false }
+
+better_any = { git = "https://github.com/aj3n/better_any.git", branch = "main", default-features = false }
 
 [features]
 default = ["std"]

--- a/move-vm-backend/Cargo.toml
+++ b/move-vm-backend/Cargo.toml
@@ -9,8 +9,18 @@ repository = "https://github.com/eigerco/substrate-move"
 description = "MoveVM backend to be used with Substrate pallet"
 
 [dependencies]
+anyhow = "1.0.75"
+move-binary-format = { path = "../language/move-binary-format", default-features = false }
+move-core-types = { path = "../language/move-core/types", default-features = false }
+move-vm-runtime = { path = "../language/move-vm/runtime", default-features = false }
+move-vm-types = { path = "../language/move-vm/types", default-features = false }
+move-stdlib = { path = "../language/move-stdlib", default-features = false }
 
 [features]
 default = ["std"]
 
-std = [ ]
+std = [
+    "move-core-types/std",
+    "move-vm-runtime/std",
+    "move-vm-types/std",
+]

--- a/move-vm-backend/Cargo.toml
+++ b/move-vm-backend/Cargo.toml
@@ -9,21 +9,22 @@ repository = "https://github.com/eigerco/substrate-move"
 description = "MoveVM backend to be used with Substrate pallet"
 
 [dependencies]
-anyhow = "1.0.75"
+anyhow = { version = "1.0.75", default-features = false }
 move-binary-format = { path = "../language/move-binary-format", default-features = false }
 move-core-types = { path = "../language/move-core/types", default-features = false, features = ["address32"] }
 move-vm-runtime = { path = "../language/move-vm/runtime", default-features = false }
 move-vm-types = { path = "../language/move-vm/types", default-features = false }
 move-stdlib = { path = "../language/move-stdlib", default-features = false, features = ["address32"] }
-move-vm-test-utils = { path = "../language/move-vm/test-utils", default-features = false }
 
 [dev-dependencies]
-move-vm-test-utils = { path = "../language/move-vm/test-utils", default-features = false }
+move-vm-test-utils = { path = "../language/move-vm/test-utils" }
 
 [features]
 default = ["std"]
 
 std = [
+    "anyhow/std",
+    "move-binary-format/std",
     "move-core-types/std",
     "move-vm-runtime/std",
     "move-vm-types/std",

--- a/move-vm-backend/Cargo.toml
+++ b/move-vm-backend/Cargo.toml
@@ -11,10 +11,10 @@ description = "MoveVM backend to be used with Substrate pallet"
 [dependencies]
 anyhow = "1.0.75"
 move-binary-format = { path = "../language/move-binary-format", default-features = false }
-move-core-types = { path = "../language/move-core/types", default-features = false }
+move-core-types = { path = "../language/move-core/types", default-features = false, features = ["address32"] }
 move-vm-runtime = { path = "../language/move-vm/runtime", default-features = false }
 move-vm-types = { path = "../language/move-vm/types", default-features = false }
-move-stdlib = { path = "../language/move-stdlib", default-features = false }
+move-stdlib = { path = "../language/move-stdlib", default-features = false, features = ["address32"] }
 
 [features]
 default = ["std"]

--- a/move-vm-backend/Cargo.toml
+++ b/move-vm-backend/Cargo.toml
@@ -15,6 +15,10 @@ move-core-types = { path = "../language/move-core/types", default-features = fal
 move-vm-runtime = { path = "../language/move-vm/runtime", default-features = false }
 move-vm-types = { path = "../language/move-vm/types", default-features = false }
 move-stdlib = { path = "../language/move-stdlib", default-features = false, features = ["address32"] }
+move-vm-test-utils = { path = "../language/move-vm/test-utils", default-features = false }
+
+[dev-dependencies]
+move-vm-test-utils = { path = "../language/move-vm/test-utils", default-features = false }
 
 [features]
 default = ["std"]

--- a/move-vm-backend/src/lib.rs
+++ b/move-vm-backend/src/lib.rs
@@ -89,13 +89,13 @@ where
             anyhow!("Error code:{:?}: msg: '{}'", code, msg.unwrap_or_default())
         })?;
 
-        for module in changeset.modules() {
-            match module.2 {
+        for (account, _, operation) in changeset.modules() {
+            match operation {
                 New(data) | Modify(data) => {
-                    self.storage.set(module.0.as_slice(), data);
+                    self.storage.set(account.as_slice(), data);
                 }
                 Delete => {
-                    self.storage.remove(module.0.as_slice());
+                    self.storage.remove(account.as_slice());
                 }
             }
         }

--- a/move-vm-backend/src/lib.rs
+++ b/move-vm-backend/src/lib.rs
@@ -4,3 +4,59 @@
 extern crate alloc;
 
 pub mod storage;
+
+use alloc::sync::Arc;
+
+use anyhow::{anyhow, Error};
+
+use move_binary_format::{
+    errors::VMResult,
+    CompiledModule,
+};
+
+use move_core_types::language_storage::{CORE_CODE_ADDRESS, ModuleId};
+use move_core_types::resolver::{ModuleResolver, ResourceResolver};
+use move_vm_runtime::move_vm::MoveVM;
+
+use move_stdlib::natives::{all_natives, GasParameters};
+
+use crate::storage::Storage;
+
+pub struct Mvm<S>
+    where
+        S: Storage + ModuleResolver<Error = Error> + ResourceResolver<Error = Error>,
+{
+    vm: MoveVM,
+    storage: S,
+}
+
+impl<S> Mvm<S>
+    where
+        S: Storage + ModuleResolver<Error = Error> + ResourceResolver<Error = Error>,
+{
+    /// Create a new Move VM with the given storage.
+    pub fn new(storage: S) -> Result<Mvm<S>, Error> {
+        Self::new_with_config(storage)
+    }
+
+    /// Create a new Move VM with the given storage and configuration.
+    pub(crate) fn new_with_config(
+        storage: S,
+        // config: VMConfig,
+    ) -> Result<Mvm<S>, Error> {
+        Ok(Mvm {
+            vm: MoveVM::new(all_natives(CORE_CODE_ADDRESS, GasParameters::zeros())).map_err(
+                |err| {
+                    let (code, _, msg, _, _, _, _) = err.all_data();
+                    anyhow!("Error code:{:?}: msg: '{}'", code, msg.unwrap_or_default())
+                },
+            )?,
+            storage,
+        })
+    }
+
+    pub fn load_module(&self, module: &ModuleId) -> Result<Arc<CompiledModule>, Error> {
+        let module = self.vm.load_module(module, &self.storage)?;
+        Ok(module)
+    }
+}

--- a/move-vm-backend/src/lib.rs
+++ b/move-vm-backend/src/lib.rs
@@ -1,6 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#[macro_use]
 extern crate alloc;
 
 pub mod storage;
@@ -9,16 +8,13 @@ use alloc::sync::Arc;
 
 use anyhow::{anyhow, Error};
 
-use move_binary_format::{
-    errors::VMResult,
-    CompiledModule,
-};
-use move_core_types::identifier::Identifier;
+use move_binary_format::CompiledModule;
+
 use move_core_types::account_address::AccountAddress;
 
-use move_core_types::language_storage::{CORE_CODE_ADDRESS, ModuleId};
+use move_core_types::effects::Op::{Delete, Modify, New};
+use move_core_types::language_storage::{ModuleId, CORE_CODE_ADDRESS};
 use move_core_types::resolver::{ModuleResolver, ResourceResolver};
-use move_core_types::effects::Op::{New, Modify, Delete};
 use move_vm_runtime::move_vm::MoveVM;
 
 use move_stdlib::natives::{all_natives, GasParameters};
@@ -26,19 +22,20 @@ use move_vm_types::gas::GasMeter;
 
 use crate::storage::Storage;
 
+/// Main MoveVM structure, which is used to represent the virutal machine itself.
 pub struct Mvm<S>
-    where
-        S: Storage + ModuleResolver<Error = Error> + ResourceResolver<Error = Error>,
+where
+    S: Storage + ModuleResolver<Error = Error> + ResourceResolver<Error = Error>,
 {
+    // MoveVM instance - from move_vm_runtime crate
     vm: MoveVM,
+    // Storage instance
     storage: S,
 }
 
-use move_vm_test_utils::InMemoryStorage;
-
 impl<S> Mvm<S>
-    where
-        S: Storage + ModuleResolver<Error = Error> + ResourceResolver<Error = Error>,
+where
+    S: Storage + ModuleResolver<Error = Error> + ResourceResolver<Error = Error>,
 {
     /// Create a new Move VM with the given storage.
     pub fn new(storage: S) -> Result<Mvm<S>, Error> {
@@ -61,64 +58,47 @@ impl<S> Mvm<S>
         })
     }
 
+    /// Load module into cache.
+    /// Module must be previously published.
     pub fn load_module(&self, module: &ModuleId) -> Result<Arc<CompiledModule>, Error> {
-        let module = self.vm.load_module(module, &self.storage)?;
+        let module = self.vm.load_module(module, &self.storage).map_err(|err| {
+            let (code, _, msg, _, _, _, _) = err.all_data();
+            anyhow!("Error code:{:?}: msg: '{}'", code, msg.unwrap_or_default())
+        })?;
+
         Ok(module)
     }
 
-
-    pub fn publish_module(&self, module: &[u8], address: AccountAddress, gas: &mut impl GasMeter) -> Result<(), Error> {
-        // Testing code
-        let addr : [u8; 32]  = [0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
-            0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xCA, 0xFE];
-
-        // Uncomment to check that storage is working
-        //self.storage.set(&addr, &module.to_vec());
-
+    /// Publish module into the storage. Module is published under the given address.
+    pub fn publish_module(
+        &self,
+        module: &[u8],
+        address: AccountAddress,
+        gas: &mut impl GasMeter,
+    ) -> Result<(), Error> {
         let mut sess = self.vm.new_session(&self.storage);
 
-        println!("addr content: {:?}", &self.storage.get(&addr));   // Testing code
+        sess.publish_module(module.to_vec(), address, gas)
+            .map_err(|err| {
+                let (code, _, msg, _, _, _, _) = err.all_data();
+                anyhow!("Error code:{:?}: msg: '{}'", code, msg.unwrap_or_default())
+            })?;
 
-        sess.publish_module(module.to_vec(), address, gas)?;
-        let (changeset, _) = sess.finish()?;
+        let (changeset, _) = sess.finish().map_err(|err| {
+            let (code, _, msg, _, _, _, _) = err.all_data();
+            anyhow!("Error code:{:?}: msg: '{}'", code, msg.unwrap_or_default())
+        })?;
 
-        for module in changeset.modules().into_iter() {
+        for module in changeset.modules() {
             match module.2 {
                 New(data) | Modify(data) => {
                     self.storage.set(module.0.as_slice(), data);
-                    println!("New module: {:?}", data);
                 }
                 Delete => {
                     self.storage.remove(module.0.as_slice());
-                    println!("Delete module");
                 }
             }
         }
-
-        println!("addr content: {:?}", &self.storage.get(&addr));   // Testing code
-
-        Ok(())
-    }
-
-    pub fn publish_module_inmemstorage(&self, module: &[u8], address: AccountAddress, gas: &mut impl GasMeter) -> Result<(), Error> {
-        // Testing code
-        let addr : [u8; 32]  = [0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
-            0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xCA, 0xFE];
-
-        let moduleId = ModuleId::new(
-            AccountAddress::new(addr),
-            Identifier::new("Empty").unwrap(),
-        );
-
-        let mut test_storage = InMemoryStorage::new();
-        let mut sess = self.vm.new_session(&test_storage);
-
-        sess.publish_module(module.to_vec(), address, gas)?;
-        let (changeset, _) = sess.finish()?;
-
-        test_storage.apply(changeset).unwrap();
-
-        println!("module content: {:?}", &test_storage.get_module(&moduleId));   // Testing code
 
         Ok(())
     }

--- a/move-vm-backend/src/lib.rs
+++ b/move-vm-backend/src/lib.rs
@@ -13,12 +13,15 @@ use move_binary_format::{
     errors::VMResult,
     CompiledModule,
 };
+use move_core_types::identifier::Identifier;
+use move_core_types::account_address::AccountAddress;
 
 use move_core_types::language_storage::{CORE_CODE_ADDRESS, ModuleId};
 use move_core_types::resolver::{ModuleResolver, ResourceResolver};
 use move_vm_runtime::move_vm::MoveVM;
 
 use move_stdlib::natives::{all_natives, GasParameters};
+use move_vm_types::gas::GasMeter;
 
 use crate::storage::Storage;
 
@@ -29,6 +32,8 @@ pub struct Mvm<S>
     vm: MoveVM,
     storage: S,
 }
+
+use move_vm_test_utils::InMemoryStorage;
 
 impl<S> Mvm<S>
     where
@@ -58,5 +63,47 @@ impl<S> Mvm<S>
     pub fn load_module(&self, module: &ModuleId) -> Result<Arc<CompiledModule>, Error> {
         let module = self.vm.load_module(module, &self.storage)?;
         Ok(module)
+    }
+
+
+    pub fn publish_module(&self, module: &[u8], address: AccountAddress, gas: &mut impl GasMeter) -> Result<(), Error> {
+        // Testing code
+        let addr : [u8; 32]  = [0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+            0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xCA, 0xFE];
+
+        // Uncomment to check that storage is working
+        //self.storage.set(&addr, &module.to_vec());
+
+        let mut sess = self.vm.new_session(&self.storage);
+
+        println!("addr content: {:?}", &self.storage.get(&addr));   // Testing code
+
+        sess.publish_module(module.to_vec(), address, gas)?;
+        sess.finish()?;
+
+        println!("addr content: {:?}", &self.storage.get(&addr));   // Testing code
+
+        Ok(())
+    }
+
+    pub fn publish_module_inmemstorage(&self, module: &[u8], address: AccountAddress, gas: &mut impl GasMeter) -> Result<(), Error> {
+        // Testing code
+        let addr : [u8; 32]  = [0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+            0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xCA, 0xFE];
+
+        let moduleId = ModuleId::new(
+            AccountAddress::new(addr),
+            Identifier::new("Empty").unwrap(),
+        );
+
+        let test_storage = InMemoryStorage::new();
+        let mut sess = self.vm.new_session(&test_storage);
+
+        sess.publish_module(module.to_vec(), address, gas)?;
+        sess.finish()?;
+
+        println!("module content: {:?}", &test_storage.get_module(&moduleId));   // Testing code
+
+        Ok(())
     }
 }

--- a/move-vm-backend/src/storage.rs
+++ b/move-vm-backend/src/storage.rs
@@ -1,4 +1,9 @@
 use alloc::vec::Vec;
+use anyhow::Error;
+
+use move_core_types::account_address::AccountAddress;
+use move_core_types::language_storage::{ModuleId, StructTag};
+use move_core_types::resolver::{ModuleResolver, ResourceResolver};
 
 /// Trait for a storage engine. This is used by the Move VM to store data. Used for
 /// mapping Substrate storage which is typical key-value container.
@@ -13,4 +18,56 @@ pub trait Storage {
 
     /// Remove `key` and its value from the storage.
     fn remove(&self, key: &[u8]);
+}
+
+/// Move VM storage implementation for Substrate storage.
+pub struct MoveStorage<S: Storage> {
+    /// Substrate storage implementing Storage trait
+    storage: S,
+}
+
+impl<S: Storage> Storage for MoveStorage<S> {
+    fn get(&self, key: &[u8]) -> Option<Vec<u8>> {
+        self.storage.get(key).map(|blob| blob.to_owned())
+    }
+
+    fn set(&self, key: &[u8], value: &[u8]) {
+        self.storage.set(key, value);
+    }
+
+    fn remove(&self, key: &[u8]) {
+        self.storage.remove(key);
+    }
+}
+
+impl<S: Storage> MoveStorage<S> {
+    pub fn new(storage: S) -> MoveStorage<S> {
+        MoveStorage { storage }
+    }
+
+}
+
+impl<S: Storage> ModuleResolver for MoveStorage<S> {
+    type Error = Error;
+
+    fn get_module(&self, module_id: &ModuleId) -> Result<Option<Vec<u8>>, Self::Error> {
+        Ok(self.storage.get(module_id.access_vector().as_slice()))
+    }
+}
+
+impl<S: Storage> ResourceResolver for MoveStorage<S> {
+    type Error = Error;
+
+    fn get_resource(
+        &self,
+        address: &AccountAddress,
+        tag: &StructTag,
+    ) -> Result<Option<Vec<u8>>, Self::Error> {
+        let tag = tag.access_vector();
+        let mut key = Vec::with_capacity(AccountAddress::LENGTH + tag.len());
+        key.extend_from_slice(address.as_ref());
+        key.extend_from_slice(&tag);
+
+        Ok(self.storage.get(key.as_slice()))
+    }
 }

--- a/move-vm-backend/src/storage.rs
+++ b/move-vm-backend/src/storage.rs
@@ -28,7 +28,7 @@ pub struct MoveStorage<S: Storage> {
 
 impl<S: Storage> Storage for MoveStorage<S> {
     fn get(&self, key: &[u8]) -> Option<Vec<u8>> {
-        self.storage.get(key).map(|blob| blob.to_owned())
+        self.storage.get(key)
     }
 
     fn set(&self, key: &[u8], value: &[u8]) {
@@ -44,7 +44,6 @@ impl<S: Storage> MoveStorage<S> {
     pub fn new(storage: S) -> MoveStorage<S> {
         MoveStorage { storage }
     }
-
 }
 
 impl<S: Storage> ModuleResolver for MoveStorage<S> {

--- a/move-vm-backend/tests/assets/move/Move.toml
+++ b/move-vm-backend/tests/assets/move/Move.toml
@@ -1,0 +1,10 @@
+[package]
+name = "move"
+version = "0.0.0"
+
+[dependencies]
+MoveStdlib = { git = "https://github.com/move-language/move.git", subdir = "language/move-stdlib", rev = "main" }
+
+[addresses]
+std =  "0x1"
+TestAccount = "0xCAFE"

--- a/move-vm-backend/tests/assets/move/scripts/empty.move
+++ b/move-vm-backend/tests/assets/move/scripts/empty.move
@@ -1,0 +1,3 @@
+script {
+    fun empty_scr() {}
+}

--- a/move-vm-backend/tests/assets/move/sources/Empty.move
+++ b/move-vm-backend/tests/assets/move/sources/Empty.move
@@ -1,0 +1,2 @@
+module TestAccount::Empty {
+}

--- a/move-vm-backend/tests/assets/move/sources/Full.move
+++ b/move-vm-backend/tests/assets/move/sources/Full.move
@@ -1,0 +1,2 @@
+module TestAccount::Full {
+}

--- a/move-vm-backend/tests/mock.rs
+++ b/move-vm-backend/tests/mock.rs
@@ -7,13 +7,13 @@ use move_vm_backend::storage::Storage;
 // Mock storage implementation for testing
 #[derive(Clone, Debug)]
 pub struct StorageMock {
-    pub data: Rc<RefCell<HashMap<Vec<u8>, Vec<u8>>>>,
+    pub data: RefCell<HashMap<Vec<u8>, Vec<u8>>>,
 }
 
 impl StorageMock {
     pub fn new() -> StorageMock {
         StorageMock {
-            data: Rc::new(RefCell::new(Default::default())),
+            data: RefCell::new(Default::default()),
         }
     }
 }

--- a/move-vm-backend/tests/mock.rs
+++ b/move-vm-backend/tests/mock.rs
@@ -1,0 +1,42 @@
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
+
+use move_vm_backend::storage::Storage;
+
+// Mock storage implementation for testing
+#[derive(Clone, Debug)]
+pub struct StorageMock {
+    pub data: Rc<RefCell<HashMap<Vec<u8>, Vec<u8>>>>,
+}
+
+impl StorageMock {
+    pub fn new() -> StorageMock {
+        StorageMock {
+            data: Rc::new(RefCell::new(Default::default())),
+        }
+    }
+}
+
+impl Default for StorageMock {
+    fn default() -> Self {
+        StorageMock::new()
+    }
+}
+
+impl Storage for StorageMock {
+    fn get(&self, key: &[u8]) -> Option<Vec<u8>> {
+        let data = self.data.borrow();
+        data.get(key).map(|blob| blob.to_owned())
+    }
+
+    fn set(&self, key: &[u8], value: &[u8]) {
+        let mut data = self.data.borrow_mut();
+        data.insert(key.to_owned(), value.to_owned());
+    }
+
+    fn remove(&self, key: &[u8]) {
+        let mut data = self.data.borrow_mut();
+        data.remove(key);
+    }
+}

--- a/move-vm-backend/tests/move_vm.rs
+++ b/move-vm-backend/tests/move_vm.rs
@@ -1,0 +1,36 @@
+use crate::mock::{StorageMock};
+
+use move_vm_backend::Mvm;
+use move_vm_backend::storage::MoveStorage;
+
+use move_core_types::account_address::AccountAddress;
+use move_core_types::language_storage::ModuleId;
+use move_core_types::identifier::Identifier;
+
+pub mod mock;
+
+#[test]
+fn load_module_test() {
+
+}
+
+#[test]
+fn load_module_not_found_test() {
+    let store = MoveStorage::new(StorageMock::new());
+    let vm = Mvm::new(store).unwrap();
+
+    let module_id = ModuleId::new(
+        AccountAddress::new([0x0; AccountAddress::LENGTH]),
+        Identifier::new("TestModule").unwrap(),
+    );
+
+    let result = vm.load_module(&module_id);
+
+    assert!(result.is_err());
+}
+
+
+    #[test]
+fn publish_module_test() {
+
+}

--- a/move-vm-backend/tests/move_vm.rs
+++ b/move-vm-backend/tests/move_vm.rs
@@ -10,8 +10,23 @@ use move_core_types::identifier::Identifier;
 pub mod mock;
 
 #[test]
-fn load_module_test() {
+fn load_module_stdlib_test() {
+    let store = MoveStorage::new(StorageMock::new());
+    let vm = Mvm::new(store).unwrap();
 
+    // or 0x1::ascii is under 0x1 address?
+    let addr : [u8; 32]  = [0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+        0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0];
+
+    let module_id = ModuleId::new(
+        AccountAddress::new(addr),
+        Identifier::new("bcs").unwrap(),
+    );
+
+    let result = vm.load_module(&module_id);
+
+    println!("{:?}", result);
+    assert!(result.is_ok());
 }
 
 #[test]

--- a/move-vm-backend/tests/move_vm.rs
+++ b/move-vm-backend/tests/move_vm.rs
@@ -1,32 +1,19 @@
 use crate::mock::{StorageMock};
 
 use move_vm_backend::Mvm;
-use move_vm_backend::storage::MoveStorage;
+use move_vm_backend::storage::{MoveStorage, Storage};
 
 use move_core_types::account_address::AccountAddress;
 use move_core_types::language_storage::ModuleId;
 use move_core_types::identifier::Identifier;
 
+use move_vm_test_utils::gas_schedule::GasStatus;
+
 pub mod mock;
 
 #[test]
-fn load_module_stdlib_test() {
-    let store = MoveStorage::new(StorageMock::new());
-    let vm = Mvm::new(store).unwrap();
+fn load_module_test() {
 
-    // or 0x1::ascii is under 0x1 address?
-    let addr : [u8; 32]  = [0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
-        0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0];
-
-    let module_id = ModuleId::new(
-        AccountAddress::new(addr),
-        Identifier::new("bcs").unwrap(),
-    );
-
-    let result = vm.load_module(&module_id);
-
-    println!("{:?}", result);
-    assert!(result.is_ok());
 }
 
 #[test]
@@ -44,8 +31,44 @@ fn load_module_not_found_test() {
     assert!(result.is_err());
 }
 
-
-    #[test]
+#[test]
 fn publish_module_test() {
+    let store = MoveStorage::new(StorageMock::new());
+    let vm = Mvm::new(store).unwrap();
 
+    let addr : [u8; 32]  = [0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+        0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xCA, 0xFE];
+
+    let module =
+        include_bytes!("assets/move/build/move/bytecode_modules/Empty.mv").to_vec();
+
+    let mut gas_status = GasStatus::new_unmetered();
+
+    let result = vm.publish_module(
+        module.as_slice(),
+        AccountAddress::new(addr),
+        &mut gas_status);
+
+    assert!(result.is_ok());
+}
+
+#[test]
+fn publish_inmemstorage_module_test() {
+    let store = MoveStorage::new(StorageMock::new());
+    let vm = Mvm::new(store).unwrap();
+
+    let addr : [u8; 32]  = [0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+        0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xCA, 0xFE];
+
+    let module =
+        include_bytes!("assets/move/build/move/bytecode_modules/Empty.mv").to_vec();
+
+    let mut gas_status = GasStatus::new_unmetered();
+
+    let result = vm.publish_module_inmemstorage(
+        module.as_slice(),
+        AccountAddress::new(addr),
+        &mut gas_status);
+
+    assert!(result.is_ok());
 }

--- a/move-vm-backend/tests/move_vm.rs
+++ b/move-vm-backend/tests/move_vm.rs
@@ -1,20 +1,18 @@
-use crate::mock::{StorageMock};
+use crate::mock::StorageMock;
 
-use move_vm_backend::Mvm;
 use move_vm_backend::storage::{MoveStorage, Storage};
+use move_vm_backend::Mvm;
 
 use move_core_types::account_address::AccountAddress;
-use move_core_types::language_storage::ModuleId;
 use move_core_types::identifier::Identifier;
+use move_core_types::language_storage::ModuleId;
 
 use move_vm_test_utils::gas_schedule::GasStatus;
 
 pub mod mock;
 
 #[test]
-fn load_module_test() {
-
-}
+fn load_module_test() {}
 
 #[test]
 fn load_module_not_found_test() {
@@ -36,39 +34,20 @@ fn publish_module_test() {
     let store = MoveStorage::new(StorageMock::new());
     let vm = Mvm::new(store).unwrap();
 
-    let addr : [u8; 32]  = [0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
-        0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xCA, 0xFE];
+    let addr: [u8; 32] = [
+        0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+        0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xCA, 0xFE,
+    ];
 
-    let module =
-        include_bytes!("assets/move/build/move/bytecode_modules/Empty.mv").to_vec();
+    let module = include_bytes!("assets/move/build/move/bytecode_modules/Empty.mv").to_vec();
 
     let mut gas_status = GasStatus::new_unmetered();
 
     let result = vm.publish_module(
         module.as_slice(),
         AccountAddress::new(addr),
-        &mut gas_status);
-
-    assert!(result.is_ok());
-}
-
-#[test]
-fn publish_inmemstorage_module_test() {
-    let store = MoveStorage::new(StorageMock::new());
-    let vm = Mvm::new(store).unwrap();
-
-    let addr : [u8; 32]  = [0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
-        0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xCA, 0xFE];
-
-    let module =
-        include_bytes!("assets/move/build/move/bytecode_modules/Empty.mv").to_vec();
-
-    let mut gas_status = GasStatus::new_unmetered();
-
-    let result = vm.publish_module_inmemstorage(
-        module.as_slice(),
-        AccountAddress::new(addr),
-        &mut gas_status);
+        &mut gas_status,
+    );
 
     assert!(result.is_ok());
 }


### PR DESCRIPTION
This PR gives the ability to run Move Virtual Machine inside the `move-vm-backend` crate, add storage and test if publishing modules work as expected. It also gives the ability to call publishing from the outer world like `pallet-move` and the real Substrate node.

Commits will be squashed.