### PR TITLE
chore: use AccountAddress to access storage instead of serialized ModuleId

### DIFF
--- a/move-vm-backend/src/storage.rs
+++ b/move-vm-backend/src/storage.rs
@@ -50,7 +50,7 @@ impl<S: Storage> ModuleResolver for MoveStorage<S> {
     type Error = Error;
 
     fn get_module(&self, module_id: &ModuleId) -> Result<Option<Vec<u8>>, Self::Error> {
-        Ok(self.storage.get(module_id.access_vector().as_slice()))
+        Ok(self.storage.get(module_id.address().as_slice()))
     }
 }
 

--- a/move-vm-backend/tests/move_vm.rs
+++ b/move-vm-backend/tests/move_vm.rs
@@ -30,6 +30,38 @@ fn load_module_not_found_test() {
 }
 
 #[test]
+fn publish_and_load_module_test() {
+    let store = MoveStorage::new(StorageMock::new());
+    let vm = Mvm::new(store).unwrap();
+
+    let addr: [u8; 32] = [
+        0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+        0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xCA, 0xFE,
+    ];
+
+    let module = include_bytes!("assets/move/build/move/bytecode_modules/Empty.mv").to_vec();
+
+    let mut gas_status = GasStatus::new_unmetered();
+
+    let result = vm.publish_module(
+        module.as_slice(),
+        AccountAddress::new(addr),
+        &mut gas_status,
+    );
+
+    assert!(result.is_ok());
+
+    let module_id = ModuleId::new(
+        AccountAddress::new(addr),
+        Identifier::new("Empty").unwrap(),
+    );
+
+    let result = vm.load_module(&module_id);
+
+    assert!(result.is_ok());
+}
+
+#[test]
 fn publish_module_test() {
     let store = MoveStorage::new(StorageMock::new());
     let vm = Mvm::new(store).unwrap();


### PR DESCRIPTION
This changes using a serialized ModuleId structure to access modules by calling the MoveResolver trait function. From now on, we are using only AccountAddress to get, set and remove items in the storage.
