### PR TITLE
feat: Warehouse keeping AccountData

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3894,6 +3894,7 @@ name = "move-vm-backend"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "hashbrown 0.14.0",
  "move-binary-format",
  "move-core-types",
  "move-stdlib",

--- a/move-vm-backend/Cargo.toml
+++ b/move-vm-backend/Cargo.toml
@@ -10,6 +10,7 @@ description = "MoveVM backend to be used with Substrate pallet"
 
 [dependencies]
 anyhow = { version = "1.0.75", default-features = false }
+hashbrown = { version = "0.14", default-features = false }
 move-binary-format = { path = "../language/move-binary-format", default-features = false }
 move-core-types = { path = "../language/move-core/types", default-features = false, features = ["address32"] }
 move-vm-runtime = { path = "../language/move-vm/runtime", default-features = false }

--- a/move-vm-backend/src/storage.rs
+++ b/move-vm-backend/src/storage.rs
@@ -1,72 +1,16 @@
-use alloc::vec::Vec;
-use anyhow::Error;
-
-use move_core_types::account_address::AccountAddress;
-use move_core_types::language_storage::{ModuleId, StructTag};
-use move_core_types::resolver::{ModuleResolver, ResourceResolver};
+use crate::warehouse::AccountData;
 
 /// Trait for a storage engine. This is used by the Move VM to store data. Used for
 /// mapping Substrate storage which is typical key-value container.
 pub trait Storage {
     /// Returns the data for specified `key`.
     /// `None` if the key cannot be obtained.
-    fn get(&self, key: &[u8]) -> Option<Vec<u8>>;
+    fn get(&self, key: &[u8]) -> Option<AccountData>;
 
     /// Set a `value` for the specified `key` in the storage.
     /// If the key is non-existent, a new key-value pair is inserted.
-    fn set(&self, key: &[u8], value: &[u8]);
+    fn set(&self, key: &[u8], value: &AccountData);
 
     /// Remove `key` and its value from the storage.
     fn remove(&self, key: &[u8]);
-}
-
-/// Move VM storage implementation for Substrate storage.
-pub struct MoveStorage<S: Storage> {
-    /// Substrate storage implementing Storage trait
-    storage: S,
-}
-
-impl<S: Storage> Storage for MoveStorage<S> {
-    fn get(&self, key: &[u8]) -> Option<Vec<u8>> {
-        self.storage.get(key)
-    }
-
-    fn set(&self, key: &[u8], value: &[u8]) {
-        self.storage.set(key, value);
-    }
-
-    fn remove(&self, key: &[u8]) {
-        self.storage.remove(key);
-    }
-}
-
-impl<S: Storage> MoveStorage<S> {
-    pub fn new(storage: S) -> MoveStorage<S> {
-        MoveStorage { storage }
-    }
-}
-
-impl<S: Storage> ModuleResolver for MoveStorage<S> {
-    type Error = Error;
-
-    fn get_module(&self, module_id: &ModuleId) -> Result<Option<Vec<u8>>, Self::Error> {
-        Ok(self.storage.get(module_id.address().as_slice()))
-    }
-}
-
-impl<S: Storage> ResourceResolver for MoveStorage<S> {
-    type Error = Error;
-
-    fn get_resource(
-        &self,
-        address: &AccountAddress,
-        tag: &StructTag,
-    ) -> Result<Option<Vec<u8>>, Self::Error> {
-        let tag = tag.access_vector();
-        let mut key = Vec::with_capacity(AccountAddress::LENGTH + tag.len());
-        key.extend_from_slice(address.as_ref());
-        key.extend_from_slice(&tag);
-
-        Ok(self.storage.get(key.as_slice()))
-    }
 }

--- a/move-vm-backend/src/warehouse.rs
+++ b/move-vm-backend/src/warehouse.rs
@@ -1,0 +1,82 @@
+use anyhow::Error;
+
+use hashbrown::HashMap;
+use move_core_types::account_address::AccountAddress;
+
+use move_core_types::identifier::Identifier;
+use move_core_types::language_storage::{ModuleId, StructTag};
+use move_core_types::resolver::{ModuleResolver, ResourceResolver};
+
+use crate::storage::Storage;
+
+/// Structure holding account data which is held under one Move address (or one key
+/// in Substrate storage).
+#[derive(Clone, Debug, Default)]
+pub struct AccountData {
+    /// Hashmap of the modules kept under this account.
+    pub modules: HashMap<Identifier, Vec<u8>>,
+    /// Hashmap of the resources kept under this account.
+    pub resources: HashMap<StructTag, Vec<u8>>,
+}
+
+/// Move VM storage implementation for Substrate storage.
+pub struct Warehouse<S: Storage> {
+    /// Substrate storage implementing Storage trait
+    storage: S,
+}
+
+impl<S: Storage> Storage for Warehouse<S> {
+    fn get(&self, key: &[u8]) -> Option<AccountData> {
+        self.storage.get(key)
+    }
+
+    fn set(&self, key: &[u8], value: &AccountData) {
+        self.storage.set(key, value);
+    }
+
+    fn remove(&self, key: &[u8]) {
+        self.storage.remove(key);
+    }
+}
+
+impl<S: Storage> Warehouse<S> {
+    pub fn new(storage: S) -> Warehouse<S> {
+        Warehouse { storage }
+    }
+}
+
+impl<S: Storage> ModuleResolver for Warehouse<S> {
+    type Error = Error;
+
+    fn get_module(&self, module_id: &ModuleId) -> Result<Option<Vec<u8>>, Self::Error> {
+        let acc = self.storage.get(module_id.address().as_slice());
+
+        if let Some(acc) = acc {
+            Ok(acc.modules.get(module_id.name()).map(|v| v.clone()))
+        } else {
+            // Even if account is not found, we still return Ok(None) - it's not an error
+            // for MoveVM.
+            Ok(None)
+        }
+    }
+}
+
+impl<S: Storage> ResourceResolver for Warehouse<S> {
+    type Error = Error;
+
+    fn get_resource(
+        &self,
+        address: &AccountAddress,
+        tag: &StructTag,
+    ) -> Result<Option<Vec<u8>>, Self::Error> {
+        let acc = self.storage.get(address.as_slice());
+
+        if let Some(acc) = acc {
+            Ok(acc.resources.get(tag).map(|v| v.clone()))
+        } else {
+            // Even if account is not found, we still return Ok(None) - it's not an error
+            // for MoveVM.
+            Ok(None)
+        }
+    }
+}

--- a/move-vm-backend/tests/mock.rs
+++ b/move-vm-backend/tests/mock.rs
@@ -1,13 +1,13 @@
 use std::cell::RefCell;
 use std::collections::HashMap;
-use std::rc::Rc;
 
 use move_vm_backend::storage::Storage;
+use move_vm_backend::warehouse::AccountData;
 
 // Mock storage implementation for testing
 #[derive(Clone, Debug)]
 pub struct StorageMock {
-    pub data: RefCell<HashMap<Vec<u8>, Vec<u8>>>,
+    pub data: RefCell<HashMap<Vec<u8>, AccountData>>,
 }
 
 impl StorageMock {
@@ -25,14 +25,14 @@ impl Default for StorageMock {
 }
 
 impl Storage for StorageMock {
-    fn get(&self, key: &[u8]) -> Option<Vec<u8>> {
+    fn get(&self, key: &[u8]) -> Option<AccountData> {
         let data = self.data.borrow();
-        data.get(key).map(|blob| blob.to_owned())
+        data.get(key).map(|blob| blob.clone())
     }
 
-    fn set(&self, key: &[u8], value: &[u8]) {
+    fn set(&self, key: &[u8], value: &AccountData) {
         let mut data = self.data.borrow_mut();
-        data.insert(key.to_owned(), value.to_owned());
+        data.insert(key.to_owned(), value.clone());
     }
 
     fn remove(&self, key: &[u8]) {

--- a/move-vm-backend/tests/move_vm.rs
+++ b/move-vm-backend/tests/move_vm.rs
@@ -1,22 +1,18 @@
 use crate::mock::StorageMock;
-
-use move_vm_backend::storage::{MoveStorage, Storage};
 use move_vm_backend::Mvm;
 
 use move_core_types::account_address::AccountAddress;
 use move_core_types::identifier::Identifier;
 use move_core_types::language_storage::ModuleId;
+use move_vm_backend::warehouse::Warehouse;
 
 use move_vm_test_utils::gas_schedule::GasStatus;
 
 pub mod mock;
 
 #[test]
-fn load_module_test() {}
-
-#[test]
 fn load_module_not_found_test() {
-    let store = MoveStorage::new(StorageMock::new());
+    let store = Warehouse::new(StorageMock::new());
     let vm = Mvm::new(store).unwrap();
 
     let module_id = ModuleId::new(
@@ -31,7 +27,7 @@ fn load_module_not_found_test() {
 
 #[test]
 fn publish_and_load_module_test() {
-    let store = MoveStorage::new(StorageMock::new());
+    let store = Warehouse::new(StorageMock::new());
     let vm = Mvm::new(store).unwrap();
 
     let addr: [u8; 32] = [
@@ -51,10 +47,7 @@ fn publish_and_load_module_test() {
 
     assert!(result.is_ok());
 
-    let module_id = ModuleId::new(
-        AccountAddress::new(addr),
-        Identifier::new("Empty").unwrap(),
-    );
+    let module_id = ModuleId::new(AccountAddress::new(addr), Identifier::new("Empty").unwrap());
 
     let result = vm.load_module(&module_id);
 
@@ -63,7 +56,7 @@ fn publish_and_load_module_test() {
 
 #[test]
 fn publish_module_test() {
-    let store = MoveStorage::new(StorageMock::new());
+    let store = Warehouse::new(StorageMock::new());
     let vm = Mvm::new(store).unwrap();
 
     let addr: [u8; 32] = [


### PR DESCRIPTION
Introduced Warehouse, which keeps AccountData set for each MoveVM account.

Each address contains two sets: modules and resources.