### PR TITLE
Feat/update warehouse storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3894,13 +3894,14 @@ name = "move-vm-backend"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "hashbrown 0.14.0",
+ "bcs 0.1.4",
  "move-binary-format",
  "move-core-types",
  "move-stdlib",
  "move-vm-runtime",
  "move-vm-test-utils",
  "move-vm-types",
+ "serde 1.0.188",
 ]
 
 [[package]]

--- a/move-vm-backend/Cargo.toml
+++ b/move-vm-backend/Cargo.toml
@@ -9,13 +9,14 @@ repository = "https://github.com/eigerco/substrate-move"
 description = "MoveVM backend to be used with Substrate pallet"
 
 [dependencies]
-anyhow = { version = "1.0.75", default-features = false }
-hashbrown = { version = "0.14", default-features = false }
+anyhow = { version = "1.0", default-features = false }
 move-binary-format = { path = "../language/move-binary-format", default-features = false }
 move-core-types = { path = "../language/move-core/types", default-features = false, features = ["address32"] }
 move-vm-runtime = { path = "../language/move-vm/runtime", default-features = false }
 move-vm-types = { path = "../language/move-vm/types", default-features = false }
 move-stdlib = { path = "../language/move-stdlib", default-features = false, features = ["address32"] }
+serde = { version = "1.0", default-features = false, features = ["derive"] }
+bcs = { git = "https://github.com/eigerco/bcs.git", default-features = false, branch = "master" }
 
 [dev-dependencies]
 move-vm-test-utils = { path = "../language/move-vm/test-utils" }

--- a/move-vm-backend/src/lib.rs
+++ b/move-vm-backend/src/lib.rs
@@ -35,7 +35,7 @@ where
 
 impl<S> Mvm<S>
 where
-    S: Storage,
+    S: Storage
 {
     /// Create a new Move VM with the given storage.
     pub fn new(storage: S) -> Result<Mvm<S>, Error> {
@@ -61,13 +61,10 @@ where
     /// Load module into cache.
     /// Module must be previously published.
     pub fn load_module(&self, module: &ModuleId) -> Result<Arc<CompiledModule>, Error> {
-        let module = self
-            .vm
-            .load_module(module, &self.warehouse)
-            .map_err(|err| {
-                let (code, _, msg, _, _, _, _) = err.all_data();
-                anyhow!("Error code:{:?}: msg: '{}'", code, msg.unwrap_or_default())
-            })?;
+        let module = self.vm.load_module(module, &self.warehouse).map_err(|err| {
+            let (code, _, msg, _, _, _, _) = err.all_data();
+            anyhow!("Error code:{:?}: msg: '{}'", code, msg.unwrap_or_default())
+        })?;
 
         Ok(module)
     }
@@ -92,8 +89,6 @@ where
             anyhow!("Error code:{:?}: msg: '{}'", code, msg.unwrap_or_default())
         })?;
 
-        self.warehouse.apply_changes(changeset);
-
-        Ok(())
+        self.warehouse.apply_changes(changeset)
     }
 }

--- a/move-vm-backend/src/lib.rs
+++ b/move-vm-backend/src/lib.rs
@@ -35,7 +35,7 @@ where
 
 impl<S> Mvm<S>
 where
-    S: Storage
+    S: Storage,
 {
     /// Create a new Move VM with the given storage.
     pub fn new(storage: S) -> Result<Mvm<S>, Error> {
@@ -61,10 +61,13 @@ where
     /// Load module into cache.
     /// Module must be previously published.
     pub fn load_module(&self, module: &ModuleId) -> Result<Arc<CompiledModule>, Error> {
-        let module = self.vm.load_module(module, &self.warehouse).map_err(|err| {
-            let (code, _, msg, _, _, _, _) = err.all_data();
-            anyhow!("Error code:{:?}: msg: '{}'", code, msg.unwrap_or_default())
-        })?;
+        let module = self
+            .vm
+            .load_module(module, &self.warehouse)
+            .map_err(|err| {
+                let (code, _, msg, _, _, _, _) = err.all_data();
+                anyhow!("Error code:{:?}: msg: '{}'", code, msg.unwrap_or_default())
+            })?;
 
         Ok(module)
     }

--- a/move-vm-backend/src/lib.rs
+++ b/move-vm-backend/src/lib.rs
@@ -8,37 +8,34 @@ pub mod warehouse;
 use alloc::sync::Arc;
 
 use anyhow::{anyhow, Error};
-use hashbrown::HashMap;
 
 use move_binary_format::CompiledModule;
 
 use move_core_types::account_address::AccountAddress;
 
-use move_core_types::effects::Op::{Delete, Modify, New};
 use move_core_types::language_storage::{ModuleId, CORE_CODE_ADDRESS};
-use move_core_types::resolver::{ModuleResolver, ResourceResolver};
 use move_vm_runtime::move_vm::MoveVM;
 
 use move_stdlib::natives::{all_natives, GasParameters};
 use move_vm_types::gas::GasMeter;
 
 use crate::storage::Storage;
-use crate::warehouse::AccountData;
+use crate::warehouse::Warehouse;
 
 /// Main MoveVM structure, which is used to represent the virutal machine itself.
 pub struct Mvm<S>
 where
-    S: Storage + ModuleResolver<Error = Error> + ResourceResolver<Error = Error>,
+    S: Storage,
 {
     // MoveVM instance - from move_vm_runtime crate
     vm: MoveVM,
     // Storage instance
-    storage: S,
+    warehouse: Warehouse<S>,
 }
 
 impl<S> Mvm<S>
 where
-    S: Storage + ModuleResolver<Error = Error> + ResourceResolver<Error = Error>,
+    S: Storage,
 {
     /// Create a new Move VM with the given storage.
     pub fn new(storage: S) -> Result<Mvm<S>, Error> {
@@ -57,17 +54,20 @@ where
                     anyhow!("Error code:{:?}: msg: '{}'", code, msg.unwrap_or_default())
                 },
             )?,
-            storage,
+            warehouse: Warehouse::new(storage),
         })
     }
 
     /// Load module into cache.
     /// Module must be previously published.
     pub fn load_module(&self, module: &ModuleId) -> Result<Arc<CompiledModule>, Error> {
-        let module = self.vm.load_module(module, &self.storage).map_err(|err| {
-            let (code, _, msg, _, _, _, _) = err.all_data();
-            anyhow!("Error code:{:?}: msg: '{}'", code, msg.unwrap_or_default())
-        })?;
+        let module = self
+            .vm
+            .load_module(module, &self.warehouse)
+            .map_err(|err| {
+                let (code, _, msg, _, _, _, _) = err.all_data();
+                anyhow!("Error code:{:?}: msg: '{}'", code, msg.unwrap_or_default())
+            })?;
 
         Ok(module)
     }
@@ -79,7 +79,7 @@ where
         address: AccountAddress,
         gas: &mut impl GasMeter,
     ) -> Result<(), Error> {
-        let mut sess = self.vm.new_session(&self.storage);
+        let mut sess = self.vm.new_session(&self.warehouse);
 
         sess.publish_module(module.to_vec(), address, gas)
             .map_err(|err| {
@@ -92,37 +92,7 @@ where
             anyhow!("Error code:{:?}: msg: '{}'", code, msg.unwrap_or_default())
         })?;
 
-        // TODO(asmie): handle this inside Warehouse
-        for (account, identifier, operation) in changeset.modules() {
-            match operation {
-                New(data) | Modify(data) => {
-                    if let Some(acc_data) = self.storage.get(account.as_slice()) {
-                        let mut acc_data = acc_data.clone();
-
-                        // This will insert or update concrete module, saving other things in the account.
-                        acc_data
-                            .modules
-                            .insert(identifier.to_owned(), data.to_vec());
-                        self.storage.set(account.as_slice(), &acc_data);
-                    } else {
-                        // This is a new account, so we need to create it.
-                        let mut acc_data = AccountData {
-                            modules: HashMap::new(),
-                            resources: HashMap::new(),
-                        };
-
-                        acc_data
-                            .modules
-                            .insert(identifier.to_owned(), data.to_vec());
-
-                        self.storage.set(account.as_slice(), &acc_data);
-                    }
-                }
-                Delete => {
-                    self.storage.remove(account.as_slice());
-                }
-            }
-        }
+        self.warehouse.apply_changes(changeset);
 
         Ok(())
     }

--- a/move-vm-backend/src/storage.rs
+++ b/move-vm-backend/src/storage.rs
@@ -1,15 +1,17 @@
-use crate::warehouse::AccountData;
+use alloc::vec::Vec;
 
 /// Trait for a storage engine. This is used by the Move VM to store data. Used for
 /// mapping Substrate storage which is typical key-value container.
 pub trait Storage {
     /// Returns the data for specified `key`.
     /// `None` if the key cannot be obtained.
-    fn get(&self, key: &[u8]) -> Option<AccountData>;
+    fn get(&self, key: &[u8]) -> Option<Vec<u8>>;
 
     /// Set a `value` for the specified `key` in the storage.
     /// If the key is non-existent, a new key-value pair is inserted.
-    fn set(&self, key: &[u8], value: &AccountData);
+    // TODO: We could use Vec<u8> for value here to avoid one clone operation. We don't usually use
+    // the value after we update it in storage.
+    fn set(&self, key: &[u8], value: &[u8]);
 
     /// Remove `key` and its value from the storage.
     fn remove(&self, key: &[u8]);

--- a/move-vm-backend/src/warehouse.rs
+++ b/move-vm-backend/src/warehouse.rs
@@ -1,70 +1,68 @@
+use crate::storage::Storage;
+use alloc::collections::{
+    btree_map::Entry::{Occupied, Vacant},
+    BTreeMap,
+};
+use alloc::vec::Vec;
+use anyhow::{bail, Error, Result};
 use core::ops::Deref;
-use alloc::collections::{btree_map, BTreeMap};
-
-use anyhow::Error;
-
 use move_core_types::account_address::AccountAddress;
-
-use move_core_types::effects::ChangeSet;
-use move_core_types::effects::Op;
+use move_core_types::effects::{
+    ChangeSet,
+    Op::{self, Delete, Modify, New},
+};
 use move_core_types::identifier::Identifier;
 use move_core_types::language_storage::{ModuleId, StructTag};
 use move_core_types::resolver::{ModuleResolver, ResourceResolver};
-use anyhow::{Result, bail};
+use serde::{Deserialize, Serialize};
 
-use crate::storage::Storage;
-
-/// Structure holding account data which is held under one Move address (or one key
+/// Structure holding account data which is held under one Move address
 /// in Substrate storage).
-#[derive(Clone, Debug, Default)]
-pub struct AccountData {
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+struct AccountData {
     /// Hashmap of the modules kept under this account.
-    pub modules: BTreeMap<Identifier, Vec<u8>>,
+    modules: BTreeMap<Identifier, Vec<u8>>,
     /// Hashmap of the resources kept under this account.
-    pub resources: BTreeMap<StructTag, Vec<u8>>,
+    resources: BTreeMap<StructTag, Vec<u8>>,
 }
 
 impl AccountData {
     fn apply_changes<K, V>(
         map: &mut BTreeMap<K, V>,
         changes: impl IntoIterator<Item = (K, Op<V>)>,
-        ) -> Result<()>
-        where
-            K: Ord + core::fmt::Debug,
-        {
-            use btree_map::Entry::*;
-            use Op::*;
-
-            for (k, op) in changes.into_iter() {
-                match (map.entry(k), op) {
-                    (Occupied(entry), New(_)) => {
-                        bail!(
-                            "Failed to apply changes -- key {:?} already exists",
-                            entry.key()
-                            )
-                    }
-                    (Occupied(entry), Delete) => {
-                        entry.remove();
-                    }
-                    (Occupied(entry), Modify(val)) => {
-                        *entry.into_mut() = val;
-                    }
-                    (Vacant(entry), New(val)) => {
-                        entry.insert(val);
-                    }
-                    (Vacant(entry), Delete | Modify(_)) => bail!(
-                        "Failed to apply changes -- key {:?} does not exist",
+    ) -> Result<()>
+    where
+        K: Ord + core::fmt::Debug,
+    {
+        for (k, op) in changes.into_iter() {
+            match (map.entry(k), op) {
+                (Occupied(entry), New(_)) => {
+                    bail!(
+                        "Failed to apply changes -- key {:?} already exists",
                         entry.key()
-                        ),
+                    )
                 }
+                (Occupied(entry), Delete) => {
+                    entry.remove();
+                }
+                (Occupied(entry), Modify(val)) => {
+                    *entry.into_mut() = val;
+                }
+                (Vacant(entry), New(val)) => {
+                    entry.insert(val);
+                }
+                (Vacant(entry), Delete | Modify(_)) => bail!(
+                    "Failed to apply changes -- key {:?} does not exist",
+                    entry.key()
+                ),
             }
-            Ok(())
         }
+        Ok(())
+    }
 }
 
-
 /// Move VM storage implementation for Substrate storage.
-pub struct Warehouse<S: Storage> {
+pub(crate) struct Warehouse<S: Storage> {
     /// Substrate storage implementing the Storage trait
     storage: S,
 }
@@ -77,13 +75,17 @@ impl<S: Storage> Warehouse<S> {
     pub(crate) fn apply_changes(&self, changeset: ChangeSet) -> Result<()> {
         for (account, changeset) in changeset.into_inner() {
             let key = account.as_slice();
-            let mut account = self.storage.get(key).unwrap_or_default();
+            let mut account = match self.storage.get(key) {
+                Some(value) => bcs::from_bytes(&value).map_err(Error::msg)?,
+                _ => AccountData::default(),
+            };
 
             let (modules, resources) = changeset.into_inner();
             AccountData::apply_changes(&mut account.modules, modules)?;
             AccountData::apply_changes(&mut account.resources, resources)?;
 
-            self.storage.set(key, &account);
+            let account_bytes = bcs::to_bytes(&account).map_err(Error::msg)?;
+            self.storage.set(key, &account_bytes);
         }
 
         Ok(())
@@ -102,15 +104,17 @@ impl<S: Storage> ModuleResolver for Warehouse<S> {
     type Error = Error;
 
     fn get_module(&self, module_id: &ModuleId) -> Result<Option<Vec<u8>>, Self::Error> {
-        let acc = self.storage.get(module_id.address().as_slice());
+        let raw_account = self.storage.get(module_id.address().as_slice());
 
-        if let Some(acc) = acc {
-            Ok(acc.modules.get(module_id.name()).cloned())
-        } else {
-            // Even if account is not found, we still return Ok(None) - it's not an error
-            // for MoveVM.
-            Ok(None)
+        if let Some(raw_account) = raw_account {
+            let mut account: AccountData = bcs::from_bytes(&raw_account).map_err(Error::msg)?;
+
+            // Using remove to get the value since the account is already a copy of data from the storage.
+            return Ok(account.modules.remove(module_id.name()));
         }
+
+        // Even if the account is not found, we still return Ok(None) - it's not an error for MoveVM.
+        Ok(None)
     }
 }
 
@@ -122,14 +126,16 @@ impl<S: Storage> ResourceResolver for Warehouse<S> {
         address: &AccountAddress,
         tag: &StructTag,
     ) -> Result<Option<Vec<u8>>, Self::Error> {
-        let acc = self.storage.get(address.as_slice());
+        let raw_account = self.storage.get(address.as_slice());
 
-        if let Some(acc) = acc {
-            Ok(acc.resources.get(tag).cloned())
-        } else {
-            // Even if account is not found, we still return Ok(None) - it's not an error
-            // for MoveVM.
-            Ok(None)
+        if let Some(raw_account) = raw_account {
+            let mut account: AccountData = bcs::from_bytes(&raw_account).map_err(Error::msg)?;
+
+            // Using remove to get the value since the account is already a copy of data from the storage.
+            return Ok(account.resources.remove(tag));
         }
+
+        // Even if the account is not found, we still return Ok(None) - it's not an error for MoveVM.
+        Ok(None)
     }
 }

--- a/move-vm-backend/tests/mock.rs
+++ b/move-vm-backend/tests/mock.rs
@@ -2,12 +2,11 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 
 use move_vm_backend::storage::Storage;
-use move_vm_backend::warehouse::AccountData;
 
 // Mock storage implementation for testing
 #[derive(Clone, Debug)]
 pub struct StorageMock {
-    pub data: RefCell<HashMap<Vec<u8>, AccountData>>,
+    pub data: RefCell<HashMap<Vec<u8>, Vec<u8>>>,
 }
 
 impl StorageMock {
@@ -25,14 +24,14 @@ impl Default for StorageMock {
 }
 
 impl Storage for StorageMock {
-    fn get(&self, key: &[u8]) -> Option<AccountData> {
+    fn get(&self, key: &[u8]) -> Option<Vec<u8>> {
         let data = self.data.borrow();
-        data.get(key).map(|blob| blob.clone())
+        data.get(key).map(|blob| blob.to_owned())
     }
 
-    fn set(&self, key: &[u8], value: &AccountData) {
+    fn set(&self, key: &[u8], value: &[u8]) {
         let mut data = self.data.borrow_mut();
-        data.insert(key.to_owned(), value.clone());
+        data.insert(key.to_owned(), value.to_owned());
     }
 
     fn remove(&self, key: &[u8]) {

--- a/move-vm-backend/tests/move_vm.rs
+++ b/move-vm-backend/tests/move_vm.rs
@@ -4,7 +4,6 @@ use move_vm_backend::Mvm;
 use move_core_types::account_address::AccountAddress;
 use move_core_types::identifier::Identifier;
 use move_core_types::language_storage::ModuleId;
-use move_vm_backend::warehouse::Warehouse;
 
 use move_vm_test_utils::gas_schedule::GasStatus;
 
@@ -20,14 +19,15 @@ fn read_bytes(file_path: &str) -> Vec<u8> {
 fn read_module_bytes_from_project(project: &str, module_name: &str) -> Vec<u8> {
     const MOVE_PROJECTS: &str = "tests/assets/move-projects";
 
-    let path = format!("{MOVE_PROJECTS}/{project}/build/{project}/bytecode_modules/{module_name}.mv");
+    let path =
+        format!("{MOVE_PROJECTS}/{project}/build/{project}/bytecode_modules/{module_name}.mv");
 
     read_bytes(&path)
 }
 
 #[test]
 fn load_module_not_found_test() {
-    let store = Warehouse::new(StorageMock::new());
+    let store = StorageMock::new();
     let vm = Mvm::new(store).unwrap();
 
     let module_id = ModuleId::new(
@@ -44,7 +44,7 @@ fn load_module_not_found_test() {
 #[ignore = "we need to build the move package before with a script before running the test"]
 // This test heavily depends on Move.toml files for thes used Move packages.
 fn publish_and_load_module_test() {
-    let store = Warehouse::new(StorageMock::new());
+    let store = StorageMock::new();
     let vm = Mvm::new(store).unwrap();
 
     let address = AccountAddress::from_hex_literal("0xCAFE").unwrap();
@@ -52,22 +52,21 @@ fn publish_and_load_module_test() {
 
     let mut gas_status = GasStatus::new_unmetered();
 
-    let result = vm.publish_module(
-        module.as_slice(),
-        address,
-        &mut gas_status,
-    );
+    let result = vm.publish_module(module.as_slice(), address, &mut gas_status);
     assert!(result.is_ok(), "Failed to publish the module");
 
     let module_id = ModuleId::new(address, Identifier::new("Empty").unwrap());
-    assert!(vm.load_module(&module_id).is_ok(), "Failed to load the module");
+    assert!(
+        vm.load_module(&module_id).is_ok(),
+        "Failed to load the module"
+    );
 }
 
 #[test]
 #[ignore = "we need to build the move package before with a script before running the test"]
 // This test heavily depends on Move.toml files for thes used Move packages.
 fn publish_module_test() {
-    let store = Warehouse::new(StorageMock::new());
+    let store = StorageMock::new();
     let vm = Mvm::new(store).unwrap();
 
     let address = AccountAddress::from_hex_literal("0xCAFE").unwrap();
@@ -75,11 +74,7 @@ fn publish_module_test() {
 
     let mut gas_status = GasStatus::new_unmetered();
 
-    let result = vm.publish_module(
-        module.as_slice(),
-        address,
-        &mut gas_status,
-    );
+    let result = vm.publish_module(module.as_slice(), address, &mut gas_status);
 
     assert!(result.is_ok(), "Failed to publish the module");
 }
@@ -89,7 +84,7 @@ fn publish_module_test() {
 #[ignore = "we need to build the move package before with a script before running the test"]
 // This test heavily depends on Move.toml files for thes used Move packages.
 fn publish_module_dependent_on_stdlib_natives() {
-    let store = Warehouse::new(StorageMock::new());
+    let store = StorageMock::new();
     let vm = Mvm::new(store).unwrap();
     let mut gas_status = GasStatus::new_unmetered();
 
@@ -101,17 +96,18 @@ fn publish_module_dependent_on_stdlib_natives() {
         &mod_using_stdlib_natives,
         addr_StdNativesUser,
         &mut gas_status,
-        );
+    );
     assert!(result.is_ok(), "The first module cannot be published");
 
-    let mod_depends_on_using_stdlib_natives = read_module_bytes_from_project("depends_on__using_stdlib_natives", "VectorUser");
+    let mod_depends_on_using_stdlib_natives =
+        read_module_bytes_from_project("depends_on__using_stdlib_natives", "VectorUser");
     let addr_TestingNatives = AccountAddress::from_hex_literal("0x4").unwrap();
 
     let result = vm.publish_module(
         &mod_depends_on_using_stdlib_natives,
         addr_TestingNatives,
         &mut gas_status,
-        );
+    );
     assert!(result.is_ok(), "The second module cannot be published");
 }
 
@@ -120,11 +116,12 @@ fn publish_module_dependent_on_stdlib_natives() {
 #[ignore = "we need to build the move package before with a script before running the test"]
 // This test heavily depends on Move.toml files for thes used Move packages.
 fn publish_module_using_stdlib_full_fails() {
-    let store = Warehouse::new(StorageMock::new());
+    let store = StorageMock::new();
     let vm = Mvm::new(store).unwrap();
     let mut gas_status = GasStatus::new_unmetered();
 
-    let mod_using_stdlib_natives = read_module_bytes_from_project("using_stdlib_full", "StringAndVector");
+    let mod_using_stdlib_natives =
+        read_module_bytes_from_project("using_stdlib_full", "StringAndVector");
     let addr_StdNativesUser = AccountAddress::from_hex_literal("0x3").unwrap();
 
     // In order to publish a module which is using the full stdlib package, we first must publish
@@ -133,6 +130,6 @@ fn publish_module_using_stdlib_full_fails() {
         &mod_using_stdlib_natives,
         addr_StdNativesUser,
         &mut gas_status,
-        );
+    );
     assert!(result.is_err(), "The module shouldn't be published");
 }


### PR DESCRIPTION
A couple of related commits:
--------
[refactor(move-vm-backend): update warehouse](https://github.com/eigerco/substrate-move/commit/b8fafa663bd0b536f17e0cc09b32c39a2924dd6a)
The `Warehouse` should internally handle all storage updates.
So, the `Storage` trait is removed from it and replaced with
`apply_changes` API.

So, the internal Warehouse storage can only be modified through
ChangeSets generated by the MoveVM.

--------

[feat(move-vm-backend): warehouse storage can handle resources](https://github.com/eigerco/substrate-move/commit/e201670af5fe98d553e4e4f6802f976b765dfa36)
Up until now, `Warehouse`'s storage only kept track of modules.
Now, there is also support for resources.

--------

[refactor(move-vm-backend): update Storage trait](https://github.com/eigerco/substrate-move/commit/50e0b87b204732ebf1e866937ffd360da65bad8c)
The storage trait shouldn't contain any backend-specific structs,
but `Vec<u8>` and `&[u8]` only.