### PR TITLE
move-vm-backend RPC API support

### DIFF
--- a/move-vm-backend/src/lib.rs
+++ b/move-vm-backend/src/lib.rs
@@ -5,16 +5,12 @@ extern crate alloc;
 pub mod storage;
 pub mod warehouse;
 
-use alloc::sync::Arc;
-
 use anyhow::{anyhow, Error};
-
-use move_binary_format::CompiledModule;
 
 use move_core_types::account_address::AccountAddress;
 
 use move_core_types::{
-    language_storage::{ModuleId, CORE_CODE_ADDRESS},
+    language_storage::CORE_CODE_ADDRESS,
     resolver::{ModuleResolver, ResourceResolver},
 };
 use move_vm_runtime::move_vm::MoveVM;
@@ -59,20 +55,6 @@ where
             )?,
             warehouse: Warehouse::new(storage),
         })
-    }
-
-    /// Load module into cache.
-    /// Module must be previously published.
-    pub fn load_module(&self, module: &ModuleId) -> Result<Arc<CompiledModule>, Error> {
-        let module = self
-            .vm
-            .load_module(module, &self.warehouse)
-            .map_err(|err| {
-                let (code, _, msg, _, _, _, _) = err.all_data();
-                anyhow!("Error code:{:?}: msg: '{}'", code, msg.unwrap_or_default())
-            })?;
-
-        Ok(module)
     }
 
     /// Get module binary using the module ID.

--- a/move-vm-backend/src/lib.rs
+++ b/move-vm-backend/src/lib.rs
@@ -13,7 +13,10 @@ use move_binary_format::CompiledModule;
 
 use move_core_types::account_address::AccountAddress;
 
-use move_core_types::language_storage::{ModuleId, CORE_CODE_ADDRESS};
+use move_core_types::{
+    language_storage::{ModuleId, CORE_CODE_ADDRESS},
+    resolver::{ModuleResolver, ResourceResolver},
+};
 use move_vm_runtime::move_vm::MoveVM;
 
 use move_stdlib::natives::{all_natives, GasParameters};
@@ -70,6 +73,34 @@ where
             })?;
 
         Ok(module)
+    }
+
+    /// Get module binary using the module ID.
+    // TODO: should we use Identifier and AccountAddress here instead to create the ModuleID?
+    pub fn get_module(&self, module_id: &[u8]) -> Result<Option<Vec<u8>>, Error> {
+        let module_id = bcs::from_bytes(module_id).map_err(Error::msg)?;
+        self.warehouse.get_module(&module_id)
+    }
+
+    /// Get module binary ABI using the module ID.
+    // TODO: should we use Identifier and AccountAddress here instead to create the ModuleID?
+    pub fn get_module_abi(&self, module_id: &[u8]) -> Result<Option<Vec<u8>>, Error> {
+        if let Some(bytecode) = self.get_module(module_id)? {
+            unimplemented!("Return computed ABI for {bytecode:?}");
+        }
+
+        Ok(None)
+    }
+
+    /// Get resource using an address and a tag.
+    // TODO: could we use Identifier and AccountAddress here instead as arguments?
+    pub fn get_resource(
+        &self,
+        address: &AccountAddress,
+        tag: &[u8],
+    ) -> Result<Option<Vec<u8>>, Error> {
+        let tag = bcs::from_bytes(tag).map_err(Error::msg)?;
+        self.warehouse.get_resource(address, &tag)
     }
 
     /// Publish module into the storage. Module is published under the given address.

--- a/move-vm-backend/tests/assets/move-projects/empty/sources/Empty.move
+++ b/move-vm-backend/tests/assets/move-projects/empty/sources/Empty.move
@@ -1,2 +1,4 @@
 module TestAccount::Empty {
+    struct EmptyStruct {
+    }
 }

--- a/move-vm-backend/tests/move_vm.rs
+++ b/move-vm-backend/tests/move_vm.rs
@@ -3,7 +3,7 @@ use move_vm_backend::Mvm;
 
 use move_core_types::account_address::AccountAddress;
 use move_core_types::identifier::Identifier;
-use move_core_types::language_storage::ModuleId;
+use move_core_types::language_storage::{ModuleId, StructTag};
 
 use move_vm_test_utils::gas_schedule::GasStatus;
 
@@ -132,4 +132,56 @@ fn publish_module_using_stdlib_full_fails() {
         &mut gas_status,
     );
     assert!(result.is_err(), "The module shouldn't be published");
+}
+
+#[test]
+#[ignore = "we need to build the move package before with a script before running the test"]
+// This test heavily depends on Move.toml files for thes used Move packages.
+fn get_module() {
+    let store = StorageMock::new();
+    let vm = Mvm::new(store).unwrap();
+
+    let address = AccountAddress::from_hex_literal("0xCAFE").unwrap();
+    let module = read_module_bytes_from_project("empty", "Empty");
+
+    let module_id = ModuleId::new(address, Identifier::new("Empty").unwrap());
+
+    let mut gas_status = GasStatus::new_unmetered();
+    let result = vm.publish_module(module.as_slice(), address, &mut gas_status);
+    assert!(result.is_ok(), "Failed to publish the module");
+
+    let result = vm.get_module(&bcs::to_bytes(&module_id).unwrap());
+    assert!(result.is_ok(), "Failed to publish the module");
+}
+
+#[test]
+#[ignore = "we need to build the move package before with a script before running the test"]
+// This test heavily depends on Move.toml files for thes used Move packages.
+fn get_resource() {
+    let store = StorageMock::new();
+    let vm = Mvm::new(store).unwrap();
+
+    let address = AccountAddress::from_hex_literal("0xCAFE").unwrap();
+    let module = read_module_bytes_from_project("empty", "Empty");
+
+    let tag = StructTag {
+        address,
+        module: Identifier::new("Empty").unwrap(),
+        name: Identifier::new("EmptyStruct").unwrap(),
+        type_params: vec![],
+    };
+
+    let mut gas_status = GasStatus::new_unmetered();
+    let result = vm.publish_module(module.as_slice(), address, &mut gas_status);
+    assert!(result.is_ok(), "Failed to publish the module");
+
+    let result = vm.get_resource(&address, &bcs::to_bytes(&tag).unwrap());
+    assert!(result.is_ok(), "Failed to publish the module");
+}
+
+#[test]
+#[ignore = "we need to build the move package before with a script before running the test"]
+// This test heavily depends on Move.toml files for thes used Move packages.
+fn get_module_abi() {
+    // TODO: implement the api
 }

--- a/move-vm-backend/tests/move_vm.rs
+++ b/move-vm-backend/tests/move_vm.rs
@@ -26,43 +26,6 @@ fn read_module_bytes_from_project(project: &str, module_name: &str) -> Vec<u8> {
 }
 
 #[test]
-fn load_module_not_found_test() {
-    let store = StorageMock::new();
-    let vm = Mvm::new(store).unwrap();
-
-    let module_id = ModuleId::new(
-        AccountAddress::new([0x1; AccountAddress::LENGTH]),
-        Identifier::new("TestModule").unwrap(),
-    );
-
-    let result = vm.load_module(&module_id);
-
-    assert!(result.is_err());
-}
-
-#[test]
-#[ignore = "we need to build the move package before with a script before running the test"]
-// This test heavily depends on Move.toml files for thes used Move packages.
-fn publish_and_load_module_test() {
-    let store = StorageMock::new();
-    let vm = Mvm::new(store).unwrap();
-
-    let address = AccountAddress::from_hex_literal("0xCAFE").unwrap();
-    let module = read_module_bytes_from_project("empty", "Empty");
-
-    let mut gas_status = GasStatus::new_unmetered();
-
-    let result = vm.publish_module(module.as_slice(), address, &mut gas_status);
-    assert!(result.is_ok(), "Failed to publish the module");
-
-    let module_id = ModuleId::new(address, Identifier::new("Empty").unwrap());
-    assert!(
-        vm.load_module(&module_id).is_ok(),
-        "Failed to load the module"
-    );
-}
-
-#[test]
 #[ignore = "we need to build the move package before with a script before running the test"]
 // This test heavily depends on Move.toml files for thes used Move packages.
 fn publish_module_test() {


### PR DESCRIPTION
[feat: move-vm-backend RPC API support](https://github.com/eigerco/substrate-move/commit/7f992cd1b30f59111adfa5b9d8d878130a8d03e8)

- Implemented 2/3 required APIs:
  - get_module
  - get_resource

The remaining `get_module_abi` will be added in the future commit.

--------
Also included in this PR:
[chore: remove load_module API from move-vm-backend](https://github.com/eigerco/substrate-move/commit/baba5ee3e321cbdd9fffe8f827cfe1cc935757cd)

It is not required.