### PR TITLE
test: additional checks for get_module and get_resource

### DIFF
--- a/move-vm-backend/tests/move_vm.rs
+++ b/move-vm-backend/tests/move_vm.rs
@@ -114,7 +114,8 @@ fn get_module() {
     assert!(result.is_ok(), "Failed to publish the module");
 
     let result = vm.get_module(&bcs::to_bytes(&module_id).unwrap());
-    assert!(result.is_ok(), "Failed to publish the module");
+    assert!(result.is_ok(), "Failed to retrieve the module");
+    assert_eq!(result.unwrap(), Some(module));                  // Check if the module content is correct
 }
 
 #[test]
@@ -139,7 +140,8 @@ fn get_resource() {
     assert!(result.is_ok(), "Failed to publish the module");
 
     let result = vm.get_resource(&address, &bcs::to_bytes(&tag).unwrap());
-    assert!(result.is_ok(), "Failed to publish the module");
+    assert!(result.is_ok(), "Failed to retrieve the resource from the module");
+    assert!(result.unwrap().is_some(), "Resource not found in the module");
 }
 
 #[test]


### PR DESCRIPTION
Checking if the operation returned Ok() is not enough for those two functions because they return Ok(None) in case of not finding module/resource.

For get_module test: added assert to check if bytecode received from the get_module call is the same which was uploaded previously using publish_module. Works fine.

For get_resource test: added a simple check if the returned value contains something, so whether we won't fall to Ok(None) case.

Unfortunately, this test fails now.
