### PR TITLE
chore: a new test for the `smove-bundle` command

### DIFF
--- a/.github/workflows/check-move-backend-pull-request.yml
+++ b/.github/workflows/check-move-backend-pull-request.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - move-vm-backend/**
+      - move-vm-backend-common/**
       - Cargo.toml
       - Cargo.lock
       - .github/workflows/check-move-backend-pull-request.yml

--- a/move-vm-backend/src/lib.rs
+++ b/move-vm-backend/src/lib.rs
@@ -21,7 +21,7 @@ use move_core_types::{
 use move_vm_runtime::move_vm::MoveVM;
 
 use move_stdlib::natives::{all_natives, GasParameters};
-use move_vm_backend_common::types::ModulePackage;
+use move_vm_backend_common::types::ModuleBundle;
 use move_vm_types::gas::GasMeter;
 
 use crate::storage::Storage;
@@ -156,7 +156,7 @@ where
         address: AccountAddress,
         gas: &mut impl GasMeter,
     ) -> Result<(), Error> {
-        let modules = ModulePackage::try_from(package)?.into_inner();
+        let modules = ModuleBundle::try_from(package)?.into_inner();
         let mut sess = self.vm.new_session(&self.warehouse);
 
         sess.publish_module_bundle(modules, address, gas)


### PR DESCRIPTION
Also
- includes `move-vm-backend-common` in the CI
- fixes broken `move-vm-backend` after a recent renaming change