### PR TITLE
feat: precompile stdlib bundle

### DIFF
--- a/language/move-stdlib/Move.toml
+++ b/language/move-stdlib/Move.toml
@@ -3,7 +3,4 @@ name = "MoveStdlib"
 version = "1.5.0"
 
 [addresses]
-std = "_"
-
-[dev-addresses]
 std = "0x1"

--- a/language/move-stdlib/build.rs
+++ b/language/move-stdlib/build.rs
@@ -1,0 +1,21 @@
+use std::error::Error;
+use std::process::Command;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let smove_run = Command::new("smove")
+        .args(["bundle"])
+        .output()
+        .expect("failed to execute process");
+
+    if !smove_run.status.success() {
+        let stderr = std::str::from_utf8(&smove_run.stderr)?;
+
+        let e = Box::<dyn Error + Send + Sync>::from(stderr);
+        return Err(e);
+    }
+
+    // Rerun in case Move source files are changed.
+    println!("cargo:rerun-if-changed=sources/");
+
+    Ok(())
+}

--- a/language/move-stdlib/nursery/Move.toml
+++ b/language/move-stdlib/nursery/Move.toml
@@ -4,6 +4,3 @@ version = "1.5.0"
 
 [dependencies]
 MoveStdlib = { local = ".." }
-
-[dev-addresses]
-std = "0x1"

--- a/language/move-stdlib/src/lib.rs
+++ b/language/move-stdlib/src/lib.rs
@@ -17,3 +17,8 @@ pub mod natives;
 
 #[cfg(feature = "std")]
 pub mod doc;
+
+/// Provides a precompiled bundle of bytecode modules.
+pub fn move_stdlib_bundle() -> &'static [u8] {
+    include_bytes!("../build/MoveStdlib/bundles/MoveStdlib.mvb")
+}

--- a/language/tools/move-cli/tests/move_unit_tests/assign_dev_addr_for_dep/Move.toml
+++ b/language/tools/move-cli/tests/move_unit_tests/assign_dev_addr_for_dep/Move.toml
@@ -6,7 +6,6 @@ version = "1.0.0"
 A = "_"
 
 [dev-addresses]
-std = "0x1"
 A = "0x2"
 B = "0x3"
 

--- a/language/tools/move-cli/tests/move_unit_tests/standalone_module_with_dev_addr_assignment/Move.toml
+++ b/language/tools/move-cli/tests/move_unit_tests/standalone_module_with_dev_addr_assignment/Move.toml
@@ -6,7 +6,6 @@ version = "1.0.0"
 A = "_"
 
 [dev-addresses]
-std = "0x1"
 A = "0x2"
 
 [dev-dependencies]

--- a/language/tools/move-cli/tests/move_unit_tests/standalone_module_with_regular_addr_assignment/Move.toml
+++ b/language/tools/move-cli/tests/move_unit_tests/standalone_module_with_regular_addr_assignment/Move.toml
@@ -5,8 +5,5 @@ version = "1.0.0"
 [addresses]
 A = "0x2"
 
-[dev-addresses]
-std = "0x1"
-
 [dev-dependencies]
 MoveStdlib = { local = "../../../../../move-stdlib" }

--- a/move-vm-backend/tests/move_vm.rs
+++ b/move-vm-backend/tests/move_vm.rs
@@ -37,17 +37,6 @@ fn read_bundle_from_project(project: &str, bundle_name: &str) -> Vec<u8> {
     read_bytes(&path)
 }
 
-/// Reads a precompiled Move stdlib module from our assets directory for specified project.
-/// This will be replaced in the future with a proper stdlib genesis initialization.
-fn read_stdlib_module_bytes_from_project(project: &str, stdlib_module_name: &str) -> Vec<u8> {
-    const MOVE_PROJECTS: &str = "tests/assets/move-projects";
-
-    let path =
-        format!("{MOVE_PROJECTS}/{project}/build/{project}/bytecode_modules/dependencies/MoveStdlib/{stdlib_module_name}.mv");
-
-    read_bytes(&path)
-}
-
 /// Reads a precompiled Move scripts from our assets directory.
 fn read_script_bytes_from_project(project: &str, script_name: &str) -> Vec<u8> {
     const MOVE_PROJECTS: &str = "tests/assets/move-projects";
@@ -205,10 +194,10 @@ fn get_resource() {
     let mut gas_status = GasStatus::new_unmetered();
 
     let addr_std = AccountAddress::from_hex_literal("0x1").unwrap();
-    let module = read_stdlib_module_bytes_from_project("basic_coin", "signer");
-    let result = vm.publish_module(&module, addr_std, &mut gas_status);
+    let stdlib = move_stdlib::move_stdlib_bundle();
+    let result = vm.publish_module_package(&stdlib, addr_std, &mut gas_status);
 
-    assert!(result.is_ok(), "Failed to publish the stdlib module");
+    assert!(result.is_ok(), "Failed to publish the stdlib bundle");
 
     let address = AccountAddress::from_hex_literal("0xCAFE").unwrap();
     let module = read_module_bytes_from_project("basic_coin", "BasicCoin");
@@ -351,10 +340,10 @@ fn execute_function_test() {
     let mut gas_status = GasStatus::new_unmetered();
 
     let addr_std = AccountAddress::from_hex_literal("0x1").unwrap();
-    let module = read_stdlib_module_bytes_from_project("basic_coin", "signer");
-    let result = vm.publish_module(&module, addr_std, &mut gas_status);
+    let stdlib = move_stdlib::move_stdlib_bundle();
+    let result = vm.publish_module_package(&stdlib, addr_std, &mut gas_status);
 
-    assert!(result.is_ok(), "Failed to publish the stdlib module");
+    assert!(result.is_ok(), "Failed to publish the stdlib bundle");
 
     let address = AccountAddress::from_hex_literal("0xCAFE").unwrap();
     let module = read_module_bytes_from_project("basic_coin", "BasicCoin");


### PR DESCRIPTION
In order to initialize the move-vm-backend, we'll need to provide a precompiled stdlib bundle.

The `smove` tool is used to compile all Move stdlib source files into a bundle before the actual compilation of the move-stdlib package even begins.

EDIT:
~_This PR can't be merged yet because we need to make sure the `smove` tool can be used in the CI files first._~
[Dependent PR](https://github.com/eigerco/substrate-move/pull/46) has been merged which makes it possible to use `smove` in GA workflow.