### PR TITLE
feat: move-vm-support library with SS58 to Move address conversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -531,6 +531,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "blake2b_simd"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -600,6 +609,15 @@ dependencies = [
  "fastrand 1.9.0",
  "futures-lite",
  "log",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5353f36341f7451062466f0b755b96ac3a9547e4d7f6b70d603fc721a7d7896"
+dependencies = [
+ "tinyvec",
 ]
 
 [[package]]
@@ -1471,6 +1489,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -3296,6 +3315,7 @@ dependencies = [
  "move-ir-types",
  "move-stdlib",
  "move-symbol-pool",
+ "move-vm-support",
  "num-bigint 0.4.4",
  "once_cell",
  "petgraph 0.5.1",
@@ -3956,6 +3976,17 @@ dependencies = [
  "once_cell",
  "sha3 0.10.8",
  "tracing",
+]
+
+[[package]]
+name = "move-vm-support"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "blake2",
+ "bs58",
+ "hex-literal",
+ "move-core-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ members = [
     "language/tools/read-write-set/types",
     "move-vm-backend",
     "move-vm-backend-common",
+    "move-vm-support",
 ]
 
 # NOTE: default-members is the complete list of binaries that form the "production Move codebase". These members should

--- a/language/move-compiler/Cargo.toml
+++ b/language/move-compiler/Cargo.toml
@@ -33,6 +33,8 @@ move-borrow-graph = { path = "../move-borrow-graph" }
 move-bytecode-source-map = { path = "../move-ir-compiler/move-bytecode-source-map" }
 move-command-line-common = { path = "../move-command-line-common" }
 
+move-vm-support = { path = "../../move-vm-support" }
+
 [dev-dependencies]
 move-stdlib = { path = "../move-stdlib" }
 datatest-stable = "0.1.1"

--- a/language/move-compiler/src/parser/lexer.rs
+++ b/language/move-compiler/src/parser/lexer.rs
@@ -419,16 +419,6 @@ fn find_token(
             return Ok((Tok::EOF, 0));
         }
     };
-    if matches!(c, 'A'..='Z' | 'a'..='z' | '1'..='9') {
-        // check for correct base58
-        let ss58_text_len = text
-            .find(|c| !matches!(c, 'A'..='Z' | 'a'..='z' | '1'..='9'))
-            .unwrap_or_else(|| text.len());
-        let ss58_candidate = &text[..ss58_text_len];
-        if let Ok(_) = move_vm_support::ss58_to_address(ss58_candidate) {
-            return Ok((Tok::NumValue, ss58_text_len));
-        }
-    }
     let (tok, len) = match c {
         '0'..='9' => {
             if text.starts_with("0x") && text.len() > 2 {

--- a/language/move-compiler/src/parser/lexer.rs
+++ b/language/move-compiler/src/parser/lexer.rs
@@ -419,6 +419,16 @@ fn find_token(
             return Ok((Tok::EOF, 0));
         }
     };
+    if matches!(c, 'A'..='Z' | 'a'..='z' | '1'..='9') {
+        // check for correct base58
+        let ss58_text_len = text
+            .find(|c| !matches!(c, 'A'..='Z' | 'a'..='z' | '1'..='9'))
+            .unwrap_or_else(|| text.len());
+        let ss58_candidate = &text[..ss58_text_len];
+        if let Ok(_) = move_vm_support::ss58_to_address(ss58_candidate) {
+            return Ok((Tok::NumValue, ss58_text_len));
+        }
+    }
     let (tok, len) = match c {
         '0'..='9' => {
             if text.starts_with("0x") && text.len() > 2 {

--- a/move-vm-support/Cargo.toml
+++ b/move-vm-support/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "move-vm-support"
+version = "0.1.0"
+authors = ["Eiger <hello@eiger.co>"]
+edition = "2021"
+
+repository = "https://github.com/eigerco/substrate-move"
+description = "MoveVM support for Substrate"
+
+[dependencies]
+anyhow = "1.0"
+blake2 = "0.10"
+bs58 = "0.5"
+move-core-types = { path = "../language/move-core/types" }
+
+[dev-dependencies]
+hex-literal = "0.4"

--- a/move-vm-support/src/lib.rs
+++ b/move-vm-support/src/lib.rs
@@ -1,0 +1,3 @@
+//! Library with helper functions for using MoveVM in Substrate-based chains.
+
+pub mod ss58_address;

--- a/move-vm-support/src/ss58_address.rs
+++ b/move-vm-support/src/ss58_address.rs
@@ -40,9 +40,11 @@ pub fn ss58_to_move_address(ss58: &str) -> Result<AccountAddress> {
     );
 
     let check_sum = &decoded_ss58[decoded_ss58.len() - CHECKSUM_LEN..];
-    let address = &decoded_ss58[decoded_ss58.len() - PUB_KEY_LEN - CHECKSUM_LEN..decoded_ss58.len() - CHECKSUM_LEN];
+    let address = &decoded_ss58
+        [decoded_ss58.len() - PUB_KEY_LEN - CHECKSUM_LEN..decoded_ss58.len() - CHECKSUM_LEN];
 
-    if check_sum != &ss58_hash(&decoded_ss58[0..decoded_ss58.len() - CHECKSUM_LEN])[0..CHECKSUM_LEN] {
+    if check_sum != &ss58_hash(&decoded_ss58[0..decoded_ss58.len() - CHECKSUM_LEN])[0..CHECKSUM_LEN]
+    {
         return Err(anyhow!("Wrong address checksum"));
     }
 
@@ -74,7 +76,7 @@ mod tests {
         let move_address = ss58_to_move_address_string(substrate_address).unwrap();
 
         assert_eq!(
-            (move_address.len() - 2) / 2,   // 2 hex chars per byte
+            (move_address.len() - 2) / 2, // 2 hex chars per byte
             PUB_KEY_LEN
         );
 
@@ -87,7 +89,7 @@ mod tests {
         let move_address = ss58_to_move_address_string(substrate_address).unwrap();
 
         assert_eq!(
-            (move_address.len() - 2) / 2,   // 2 hex chars per byte
+            (move_address.len() - 2) / 2, // 2 hex chars per byte
             PUB_KEY_LEN
         );
 

--- a/move-vm-support/src/ss58_address.rs
+++ b/move-vm-support/src/ss58_address.rs
@@ -62,19 +62,13 @@ pub fn ss58_to_move_address(ss58: &str) -> Result<AccountAddress> {
 
     // Sanity checks here
     match addr_type_len {
-        ADDR_TYPE_MIN_LEN => {
-            if addr_type[0] > 63 && addr_type[0] < 128 {
-                bail!("invalid address length, address types from 64 to 127 are two bytes long");
-            }
+        ADDR_TYPE_MIN_LEN if (64..=127).contains(&addr_type[0]) => {
+            bail!("invalid address length, address types from 64 to 127 are two bytes long");
         }
-        ADDR_TYPE_MAX_LEN => {
-            if addr_type[0] < 64 {
-                bail!(
-                    "invalid address length, address types from 0 to 63 are exactly one byte long"
-                );
-            }
+        ADDR_TYPE_MAX_LEN if (0..=63).contains(&addr_type[0]) => {
+            bail!("invalid address length, address types from 0 to 63 are exactly one byte long");
         }
-        _ => unreachable!(),
+        _ => (),
     }
 
     AccountAddress::from_bytes(address).map_err(anyhow::Error::msg)

--- a/move-vm-support/src/ss58_address.rs
+++ b/move-vm-support/src/ss58_address.rs
@@ -1,0 +1,114 @@
+//! SS58 address format converter for Substrate and Move accounts.
+//! Based on the Pontem solution.
+
+use anyhow::{anyhow, ensure, Result};
+use blake2::{Blake2b512, Digest};
+use move_core_types::account_address::AccountAddress;
+
+// Substrate address prefix
+// Read more: https://docs.substrate.io/reference/address-formats/
+const SS58_PREFIX: &[u8] = b"SS58PRE";
+
+// Public key length in bytes
+const PUB_KEY_LENGTH: usize = 32;
+
+// Checksum length in bytes
+const CHECK_SUM_LEN: usize = 2;
+
+// Blake2b512 hash length in bytes
+const HASH_LEN: usize = 64;
+
+/// Convert ss58 address string to Move address structure
+/// In case if such conversion is not possible, return error.
+/// ```
+/// use move_vm_support::ss58_address::ss58_to_move_address;
+/// let substrate_address = "gkNW9pAcCHxZrnoVkhLkEQtsLsW5NWTC75cdAdxAMs9LNYCYg";
+/// let move_address = ss58_to_move_address(substrate_address).unwrap();
+/// assert_eq!(
+///    "0x8EAF04151687736326C9FEA17E25FC5287613693C912909CB226AA4794F26A48",
+///   format!("{:#X}", move_address)
+/// );
+/// ```
+pub fn ss58_to_move_address(ss58: &str) -> Result<AccountAddress> {
+    let bs58 = bs58::decode(ss58).into_vec()?;
+
+    ensure!(
+        bs58.len() > PUB_KEY_LENGTH + CHECK_SUM_LEN,
+        format!(
+            "Address length must be equal or greater than {} bytes",
+            PUB_KEY_LENGTH + CHECK_SUM_LEN
+        )
+    );
+
+    let check_sum = &bs58[bs58.len() - CHECK_SUM_LEN..];
+    let address = &bs58[bs58.len() - PUB_KEY_LENGTH - CHECK_SUM_LEN..bs58.len() - CHECK_SUM_LEN];
+
+    if check_sum != &ss58_hash(&bs58[0..bs58.len() - CHECK_SUM_LEN])[0..CHECK_SUM_LEN] {
+        return Err(anyhow!("Wrong address checksum"));
+    }
+
+    let mut addr = [0; PUB_KEY_LENGTH];
+    addr.copy_from_slice(address);
+    Ok(AccountAddress::new(addr))
+}
+
+/// Convert SS58 address to Move address string.
+pub fn ss58_to_move_address_string(ss58: &str) -> Result<String> {
+    Ok(format!("{:#X}", ss58_to_move_address(ss58)?))
+}
+
+// Helper function which calculates the BLAKE2b512 hash of the given data.
+fn ss58_hash(data: &[u8]) -> [u8; HASH_LEN] {
+    let mut hasher = Blake2b512::new();
+    hasher.update(SS58_PREFIX);
+    hasher.update(data);
+    hasher.finalize().into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ss58_to_move_correct() {
+        let substrate_address = "gkNW9pAcCHxZrnoVkhLkEQtsLsW5NWTC75cdAdxAMs9LNYCYg";
+        let move_address = ss58_to_move_address_string(substrate_address).unwrap();
+
+        assert_eq!(
+            (move_address.len() - 2) / 2,   // 2 hex chars per byte
+            PUB_KEY_LENGTH
+        );
+
+        assert_eq!(
+            "0x8EAF04151687736326C9FEA17E25FC5287613693C912909CB226AA4794F26A48",
+            move_address
+        );
+
+        let substrate_address = "G7UkJAutjbQyZGRiP8z5bBSBPBJ66JbTKAkFDq3cANwENyX";
+        let move_address = ss58_to_move_address_string(substrate_address).unwrap();
+
+        assert_eq!(
+            (move_address.len() - 2) / 2,   // 2 hex chars per byte
+            PUB_KEY_LENGTH
+        );
+
+        assert_eq!(
+            "0x9C786090E2598AE884FF9D1F01D6A1A9BAF13A9E61F73633A8928F4D80BF7DFE",
+            move_address
+        );
+    }
+
+    #[test]
+    fn test_ss58_to_move_fail() {
+        let substrate_address = "G7UkJAutjbQyZGRiP8z5bBSBPBJ66JbTKAkFDq3c"; // too short
+        assert!(ss58_to_move_address_string(substrate_address).is_err());
+    }
+
+    #[test]
+    fn test_ss58hash() {
+        let msg = b"hello, world!";
+        let hash = ss58_hash(msg).to_vec();
+
+        assert_eq!(hex_literal::hex!("656facfcf4f90cce9ec9b65c9185ea75346507c67e25133f5809b442487468a674973f9167193e86bee0c706f6766f7edf638ed3e21ad12c2908ea62924af4d7").to_vec(), hash);
+    }
+}

--- a/move-vm-support/src/ss58_address.rs
+++ b/move-vm-support/src/ss58_address.rs
@@ -27,7 +27,7 @@ const ADDR_TYPE_MIN_LEN: usize = 1;
 const SS58_MAX_LEN: usize = ADDR_TYPE_MAX_LEN + PUB_KEY_LEN + CHECKSUM_LEN;
 
 // Minimum supported SS58 address length in bytes
-const SS58_MIN_LEN: usize =  ADDR_TYPE_MIN_LEN + PUB_KEY_LEN + CHECKSUM_LEN;
+const SS58_MIN_LEN: usize = ADDR_TYPE_MIN_LEN + PUB_KEY_LEN + CHECKSUM_LEN;
 
 /// Convert ss58 address string to Move address structure
 /// In case if such conversion is not possible, return error.
@@ -69,7 +69,9 @@ pub fn ss58_to_move_address(ss58: &str) -> Result<AccountAddress> {
         }
         ADDR_TYPE_MAX_LEN => {
             if addr_type[0] < 64 {
-                bail!("invalid address length, address types from 0 to 63 are exactly one byte long");
+                bail!(
+                    "invalid address length, address types from 0 to 63 are exactly one byte long"
+                );
             }
         }
         _ => unreachable!(),

--- a/move-vm-support/src/ss58_address.rs
+++ b/move-vm-support/src/ss58_address.rs
@@ -1,6 +1,6 @@
 //! SS58 address format converter for Substrate and Move accounts.
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::{bail, Result};
 use blake2::{Blake2b512, Digest};
 use move_core_types::account_address::AccountAddress;
 
@@ -54,7 +54,7 @@ pub fn ss58_to_move_address(ss58: &str) -> Result<AccountAddress> {
 
     let (type_and_addr, checksum) = &decoded_ss58.split_at(addr_type_len + PUB_KEY_LEN);
 
-    if *checksum != &ss58_checksum(&type_and_addr) {
+    if *checksum != ss58_checksum(type_and_addr) {
         bail!("invalid address checksum");
     }
 


### PR DESCRIPTION
Library with support and helper functions for using MoveVM in Substrate-based chains.

Initial commit with SS58 to Move address conversion.