### PR TITLE
ss58_to_move_to_ss58 test correct but failing

### DIFF
--- a/move-vm-support/src/ss58_address.rs
+++ b/move-vm-support/src/ss58_address.rs
@@ -123,6 +123,8 @@ fn ss58_checksum(data: &[u8]) -> [u8; CHECKSUM_LEN] {
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
     use super::*;
 
     #[test]
@@ -191,18 +193,18 @@ mod tests {
 
     #[test]
     fn ss58_to_move_to_ss58_cycle_correct() {
-        const substrate_address_literal: &str = "gkNW9pAcCHxZrnoVkhLkEQtsLsW5NWTC75cdAdxAMs9LNYCYg";
-        let move_address = ss58_to_move_address_string(substrate_address_literal).unwrap();
+        const S_A_L: &str = "gkNW9pAcCHxZrnoVkhLkEQtsLsW5NWTC75cdAdxAMs9LNYCYg";
+        let move_address = ss58_to_move_address_string(S_A_L).unwrap();
         let substrate_address =
-            move_address_to_ss58_string(&AccountAddress::from_hex_literal(&move_address).unwrap());
-        assert_eq!(substrate_address_literal, substrate_address);
+            move_address_to_ss58_string(&AccountAddress::from_str(&move_address).unwrap());
+        assert_eq!(S_A_L, substrate_address);
     }
 
     #[test]
     #[should_panic]
     fn move_address_to_ss58_string_fail() {
         let move_address = "0x8EAF04151687736326C9FEA17E25FC5287613693C912909CB226AA4794F26A48AA"; // too long
-        let substrate_address =
+        let _ =
             move_address_to_ss58_string(&AccountAddress::from_hex_literal(move_address).unwrap());
     }
 }

--- a/move-vm-support/src/ss58_address.rs
+++ b/move-vm-support/src/ss58_address.rs
@@ -190,6 +190,15 @@ mod tests {
     }
 
     #[test]
+    fn ss58_to_move_to_ss58_cycle_correct() {
+        const substrate_address_literal: &str = "gkNW9pAcCHxZrnoVkhLkEQtsLsW5NWTC75cdAdxAMs9LNYCYg";
+        let move_address = ss58_to_move_address_string(substrate_address_literal).unwrap();
+        let substrate_address =
+            move_address_to_ss58_string(&AccountAddress::from_hex_literal(&move_address).unwrap());
+        assert_eq!(substrate_address_literal, substrate_address);
+    }
+
+    #[test]
     #[should_panic]
     fn move_address_to_ss58_string_fail() {
         let move_address = "0x8EAF04151687736326C9FEA17E25FC5287613693C912909CB226AA4794F26A48AA"; // too long


### PR DESCRIPTION
Apparently different base provides different results as this test fails with the round cycle of reversing function.

Not sure if this SHOLD pass at this stage but looks weird.