### PR TITLE
feat: change API for get_module(_abi) to pass not serialized parameters

### DIFF
--- a/move-vm-backend/src/lib.rs
+++ b/move-vm-backend/src/lib.rs
@@ -94,14 +94,22 @@ where
     }
 
     /// Get module binary using the address and the name.
-    pub fn get_module(&self, address: AccountAddress, name: &str) -> Result<Option<Vec<u8>>, Error> {
+    pub fn get_module(
+        &self,
+        address: AccountAddress,
+        name: &str,
+    ) -> Result<Option<Vec<u8>>, Error> {
         let ident = Identifier::new(name)?;
         let module_id = ModuleId::new(address, ident);
         self.warehouse.get_module(&module_id)
     }
 
     /// Get module binary ABI using the address and the name.
-    pub fn get_module_abi(&self, address: AccountAddress, name: &str) -> Result<Option<Vec<u8>>, Error> {
+    pub fn get_module_abi(
+        &self,
+        address: AccountAddress,
+        name: &str,
+    ) -> Result<Option<Vec<u8>>, Error> {
         if let Some(bytecode) = self.get_module(address, name)? {
             return Ok(Some(
                 bcs::to_bytes(&ModuleAbi::from(

--- a/move-vm-backend/src/lib.rs
+++ b/move-vm-backend/src/lib.rs
@@ -93,17 +93,16 @@ where
         })
     }
 
-    /// Get module binary using the module ID.
-    // TODO: should we use Identifier and AccountAddress here instead to create the ModuleID?
-    pub fn get_module(&self, module_id: &[u8]) -> Result<Option<Vec<u8>>, Error> {
-        let module_id = bcs::from_bytes(module_id).map_err(Error::msg)?;
+    /// Get module binary using the address and the name.
+    pub fn get_module(&self, address: AccountAddress, name: &str) -> Result<Option<Vec<u8>>, Error> {
+        let ident = Identifier::new(name)?;
+        let module_id = ModuleId::new(address, ident);
         self.warehouse.get_module(&module_id)
     }
 
-    /// Get module binary ABI using the module ID.
-    // TODO: should we use Identifier and AccountAddress here instead to create the ModuleID?
-    pub fn get_module_abi(&self, module_id: &[u8]) -> Result<Option<Vec<u8>>, Error> {
-        if let Some(bytecode) = self.get_module(module_id)? {
+    /// Get module binary ABI using the address and the name.
+    pub fn get_module_abi(&self, address: AccountAddress, name: &str) -> Result<Option<Vec<u8>>, Error> {
+        if let Some(bytecode) = self.get_module(address, name)? {
             return Ok(Some(
                 bcs::to_bytes(&ModuleAbi::from(
                     CompiledModule::deserialize(&bytecode).map_err(Error::msg)?,

--- a/move-vm-backend/tests/move_vm.rs
+++ b/move-vm-backend/tests/move_vm.rs
@@ -3,7 +3,7 @@ use move_vm_backend::Mvm;
 
 use move_core_types::account_address::AccountAddress;
 use move_core_types::identifier::Identifier;
-use move_core_types::language_storage::{ModuleId, StructTag};
+use move_core_types::language_storage::StructTag;
 use move_vm_backend_common::types::ModuleBundle;
 
 use move_core_types::language_storage::TypeTag;

--- a/move-vm-backend/tests/move_vm.rs
+++ b/move-vm-backend/tests/move_vm.rs
@@ -188,21 +188,18 @@ fn get_module_and_module_abi() {
     let module = read_module_bytes_from_project("using_stdlib_natives", "Vector");
     let address = AccountAddress::from_hex_literal("0x2").unwrap();
 
-    let module_id =
-        bcs::to_bytes(&ModuleId::new(address, Identifier::new("Vector").unwrap())).unwrap();
-
     let mut gas_status = GasStatus::new_unmetered();
     let result = vm.publish_module(&module, address, &mut gas_status);
     assert!(result.is_ok(), "failed to publish the module");
 
-    let result = vm.get_module(&module_id);
+    let result = vm.get_module(address, "Vector");
     assert_eq!(
         result.expect("failed to get the module"),
         Some(module),
         "invalid module received"
     );
 
-    let result = vm.get_module_abi(&module_id);
+    let result = vm.get_module_abi(address, "Vector");
     assert!(result.unwrap().is_some(), "failed to get the module abi");
 }
 


### PR DESCRIPTION
New, more user-friendly API for communication with the pallet. 
Now, we don't need to expose the `Identifier` and `ModuleId` types to the upper layer.