### PR TITLE
build(features): debugging feature build fix in no-default-features

### DIFF
--- a/language/move-vm/runtime/Cargo.toml
+++ b/language/move-vm/runtime/Cargo.toml
@@ -29,7 +29,7 @@ default = ["std"]
 fuzzing = ["move-vm-types/fuzzing"]
 failpoints = ["fail/failpoints"]
 # Enable tracing and debugging also for release builds. By default, it is only enabled for debug builds.
-debugging = ["once_cell/std"]
+debugging = ["once_cell/std", "std"]
 testing = []
 stacktrace = []
 lazy_natives = []
@@ -40,5 +40,4 @@ std = [
     "move-core-types/std",
     "move-vm-types/std",
     "move-binary-format/std",
-    "once_cell/std"
 ]

--- a/language/move-vm/runtime/src/interpreter.rs
+++ b/language/move-vm/runtime/src/interpreter.rs
@@ -2,10 +2,12 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#[cfg(feature = "debugging")]
+use crate::trace;
+
 use crate::{
     loader::{Function, Loader, Resolver},
     native_functions::NativeContext,
-    trace,
 };
 use move_binary_format::{
     errors::*,
@@ -1760,6 +1762,7 @@ impl Frame {
         let code = self.function.code();
         loop {
             for instruction in &code[self.pc as usize..] {
+                #[cfg(feature = "debugging")]
                 trace!(
                     &self.function,
                     &self.locals,

--- a/language/move-vm/runtime/src/lib.rs
+++ b/language/move-vm/runtime/src/lib.rs
@@ -25,11 +25,12 @@ pub mod native_functions;
 mod runtime;
 pub mod session;
 #[macro_use]
+#[cfg(feature = "debugging")]
 mod tracing;
 pub mod config;
 
 // Only include debugging functionality in debug builds
-#[cfg(any(debug_assertions, feature = "debugging"))]
+#[cfg(feature = "debugging")]
 mod debug;
 
 #[cfg(test)]


### PR DESCRIPTION
* featuregated `trace` with `debugging` feature;
* fixed `debuigging` feature to use `std` feature and build in `no-std` or --no-default-features;