### PR TITLE
Build solution for the smove tool which can be used to run tests in the CI

### DIFF
--- a/.github/actions/build-setup/action.yml
+++ b/.github/actions/build-setup/action.yml
@@ -64,3 +64,15 @@ runs:
         echo 'RUST_BACKTRACE=1' | tee -a $GITHUB_ENV
         echo 'DIEM_DUMP_LOGS=1' | tee -a $GITHUB_ENV
         echo 'CARGO_INCREMENTAL=0' | tee -a $GITHUB_ENV
+    - name: Get smove
+      uses: robinraju/release-downloader@v1.8
+      with:
+        repository: "eigerco/smove"
+        fileName: "smove.zip"
+        latest: true
+        extract: true
+    - name: Setup smove
+      shell: bash
+      run: |
+         echo "$GITHUB_WORKSPACE" >> $GITHUB_PATH
+         chmod +x "$GITHUB_WORKSPACE/smove"

--- a/.github/workflows/check-move-backend-pull-request.yml
+++ b/.github/workflows/check-move-backend-pull-request.yml
@@ -29,7 +29,5 @@ jobs:
 
       - uses: ./.github/actions/build-setup
 
-      # move-vm-runtime
-
       - name: Run move-vm-backend tests
-        run: cargo test -p move-vm-backend
+        run: cargo test -p move-vm-backend --features build-move-projects-for-test

--- a/README.md
+++ b/README.md
@@ -4,33 +4,16 @@
 
 ![Move logo](assets/color/SVG/Move_Logo_Design_Digital_Final_-01.svg)
 
-# The Move Language
+# MoveVM for the Substrate
 
-Move is a programming language for writing safe smart contracts originally developed at Facebook to power the Diem blockchain. Move is designed to be a platform-agnostic language to enable common libraries, tooling, and developer communities across diverse blockchains with vastly different data and execution models. Move's ambition is to become the "JavaScript of web3" in terms of ubiquity--when developers want to quickly write safe code involving assets, it should be written in Move.
+_This project is still in progress, so this document still needs to be updated._
 
-This repository is the official home of the Move virtual machine, bytecode verifier, compiler, prover, package manager, and book. For Move code examples and papers, check out [awesome-move](https://github.com/MystenLabs/awesome-move).
+This is a modified MoveVM fork for the use of MoveVM in the [pallet-move](https://github.com/eigerco/pallet-move) Substrate repo.
 
-## Quickstart
+## Requirements
 
-### Build the [Docker](https://www.docker.com/community/open-source/) Image for the Command Line Tool
-
-```
-docker build -t move/cli -f docker/move-cli/Dockerfile .
-```
-
-### Build a Test Project
-
-```
-cd ./language/documentation/tutorial/step_1/BasicCoin
-docker run -v `pwd`:/project move/cli build
-```
-
-Follow the [language/documentation/tutorial](./language/documentation/tutorial/README.md) to set up move for development.
-
-## Community
-
-* Join us on the [Move Discord](https://discord.gg/cPUmhe24Mz).
-* Browse code and content from the community at [awesome-move](https://github.com/MystenLabs/awesome-move).
+### smove
+`smove` is a package manager for Move language in Substrate. Follow the [instructions](https://github.com/eigerco/smove) to install it.
 
 ## License
 

--- a/move-vm-backend/Cargo.toml
+++ b/move-vm-backend/Cargo.toml
@@ -24,6 +24,9 @@ move-vm-test-utils = { path = "../language/move-vm/test-utils" }
 [features]
 default = ["std"]
 
+# Builds move projects for test purposes.
+build-move-projects-for-test = []
+
 std = [
     "anyhow/std",
     "move-binary-format/std",

--- a/move-vm-backend/build.rs
+++ b/move-vm-backend/build.rs
@@ -1,0 +1,33 @@
+use std::error::Error;
+use std::process::Command;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    // Build move projects for the test purposes.
+    #[cfg(feature = "build-move-projects-for-test")]
+    build_move_projects()?;
+
+    Ok(())
+}
+
+#[allow(dead_code)]
+fn build_move_projects() -> Result<(), Box<dyn Error>> {
+    println!("cargo:warning=Building move projects in tests/assets folder");
+
+    let smove_run = Command::new("bash")
+        .args(["tests/assets/move-projects/smove-build-all.sh"])
+        .output()
+        .expect("failed to execute script which builds necessary move modules");
+
+    if !smove_run.status.success() {
+        let stderr = std::str::from_utf8(&smove_run.stderr)?;
+
+        let e = Box::<dyn Error + Send + Sync>::from(stderr);
+        return Err(e);
+    }
+
+    println!("cargo:warning=Move projects built successfully");
+    // Rerun in case Move source files are changed.
+    println!("cargo:rerun-if-changed=tests/assets/move-projects");
+
+    Ok(())
+}

--- a/move-vm-backend/tests/assets/move-projects/smove-build-all.sh
+++ b/move-vm-backend/tests/assets/move-projects/smove-build-all.sh
@@ -1,0 +1,19 @@
+# #!/bin/bash
+
+# Position the cwd in the same folder with the script (where the below folders are located)
+cd $(dirname $0)
+
+build_dir=("address_checks" "basic_coin" "depends_on__using_stdlib_full" "depends_on__using_stdlib_natives" "empty" "simple_scripts" "using_stdlib_full")
+bundle_dir=("using_stdlib_natives")
+
+# Build simple packages
+for i in "${build_dir[@]}"; do
+    echo $i
+    smove build -p $i
+done
+
+# Build bundles
+for i in "${bundle_dir[@]}"; do
+    echo $i
+    smove bundle -p $i
+done

--- a/move-vm-backend/tests/move_vm.rs
+++ b/move-vm-backend/tests/move_vm.rs
@@ -59,7 +59,6 @@ fn read_script_bytes_from_project(project: &str, script_name: &str) -> Vec<u8> {
 }
 
 #[test]
-#[ignore = "we need to build the move package before with a script before running the test"]
 // This test heavily depends on Move.toml files for thes used Move packages.
 fn publish_module_test() {
     let store = StorageMock::new();
@@ -76,7 +75,6 @@ fn publish_module_test() {
 }
 
 #[test]
-#[ignore = "we need to build the move package before with a script before running the test"]
 // This test heavily depends on Move.toml files for thes used Move packages.
 fn publish_module_package_from_multiple_module_files() {
     let store = StorageMock::new();
@@ -109,7 +107,6 @@ fn publish_module_package_from_multiple_module_files() {
 }
 
 #[test]
-#[ignore = "we need to build the move package before with a script before running the test"]
 // This test heavily depends on Move.toml files for thes used Move packages.
 fn publish_module_package_from_bundle_file() {
     let store = StorageMock::new();
@@ -125,7 +122,6 @@ fn publish_module_package_from_bundle_file() {
 
 #[allow(non_snake_case)]
 #[test]
-#[ignore = "we need to build the move package before with a script before running the test"]
 // This test heavily depends on Move.toml files for thes used Move packages.
 fn publish_module_dependent_on_stdlib_natives() {
     let store = StorageMock::new();
@@ -157,7 +153,6 @@ fn publish_module_dependent_on_stdlib_natives() {
 
 #[allow(non_snake_case)]
 #[test]
-#[ignore = "we need to build the move package before with a script before running the test"]
 // This test heavily depends on Move.toml files for thes used Move packages.
 fn publish_module_using_stdlib_full_fails() {
     let store = StorageMock::new();
@@ -179,7 +174,6 @@ fn publish_module_using_stdlib_full_fails() {
 }
 
 #[test]
-#[ignore = "we need to build the move package before with a script before running the test"]
 // This test heavily depends on Move.toml files for thes used Move packages.
 fn get_module_and_module_abi() {
     let store = StorageMock::new();
@@ -204,7 +198,6 @@ fn get_module_and_module_abi() {
 }
 
 #[test]
-#[ignore = "we need to build the move package before with a script before running the test"]
 // This test heavily depends on Move.toml files for thes used Move packages.
 fn get_resource() {
     let store = StorageMock::new();
@@ -262,7 +255,6 @@ fn get_resource() {
 }
 
 #[test]
-#[ignore = "we need to build the move package before with a script before running the test"]
 fn execute_script_with_no_params_test() {
     let store = StorageMock::new();
     let vm = Mvm::new(store).unwrap();
@@ -280,7 +272,6 @@ fn execute_script_with_no_params_test() {
 }
 
 #[test]
-#[ignore = "we need to build the move package before with a script before running the test"]
 fn execute_script_params_test() {
     let store = StorageMock::new();
     let vm = Mvm::new(store).unwrap();
@@ -299,7 +290,6 @@ fn execute_script_params_test() {
 }
 
 #[test]
-#[ignore = "we need to build the move package before with a script before running the test"]
 fn execute_script_generics_test() {
     let store = StorageMock::new();
     let vm = Mvm::new(store).unwrap();
@@ -327,7 +317,6 @@ fn execute_script_generics_test() {
 }
 
 #[test]
-#[ignore = "we need to build the move package before with a script before running the test"]
 fn execute_script_generics_incorrect_params_test() {
     let store = StorageMock::new();
     let vm = Mvm::new(store).unwrap();
@@ -356,7 +345,6 @@ fn execute_script_generics_incorrect_params_test() {
 }
 
 #[test]
-#[ignore = "we need to build the move package before with a script before running the test"]
 fn execute_function_test() {
     let store = StorageMock::new();
     let vm = Mvm::new(store).unwrap();


### PR DESCRIPTION
- [feat(move-vm-backend): add script for building move projects](https://github.com/eigerco/substrate-move/commit/ffcf7f123836680ebb06b190424578d6f76c6fbf)

    Added a new feature which can be used to compile all the necessary move
projects in the tests/assets/move-projects/ directory.

    Running:
    ```
    cargo test -p move-vm-backend --features build-move-projects-for-test
    ```
    will always succeed (the only requirement is to have smove installed).

- [doc(readme): first version of the doc](https://github.com/eigerco/substrate-move/commit/94c20588dce30df4ce91584186d22fa67448489b)

- [ci: get smove in order to use it in the CI](https://github.com/eigerco/substrate-move/commit/093f091d16e18f6e679b4ca10a595121e9e97ec7)

  - updated the instructions for running move-vm-backend tests with a
    feature flag to compile required move projects before running the
    tests.