### PR TITLE
fix(stdlib): feature for stdlib bytecode

### DIFF
--- a/language/move-stdlib/Cargo.toml
+++ b/language/move-stdlib/Cargo.toml
@@ -37,6 +37,7 @@ move-package = { path = "../tools/move-package" }
 
 [features]
 default = ["std", "address32"]
+stdlib-bytecode = []
 testing = []
 address20 = ["move-core-types/address20"]
 address32 = ["move-core-types/address32"]

--- a/language/move-stdlib/build.rs
+++ b/language/move-stdlib/build.rs
@@ -2,6 +2,14 @@ use std::error::Error;
 use std::process::Command;
 
 fn main() -> Result<(), Box<dyn Error>> {
+    #[cfg(feature = "stdlib-bytecode")]
+    build_stdlib_with_smove()?;
+
+    Ok(())
+}
+
+#[allow(dead_code)]
+fn build_stdlib_with_smove() -> Result<(), Box<dyn Error>> {
     let smove_run = Command::new("smove")
         .args(["bundle"])
         .output()
@@ -16,6 +24,5 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // Rerun in case Move source files are changed.
     println!("cargo:rerun-if-changed=sources/");
-
     Ok(())
 }

--- a/language/move-stdlib/src/lib.rs
+++ b/language/move-stdlib/src/lib.rs
@@ -18,6 +18,7 @@ pub mod natives;
 #[cfg(feature = "std")]
 pub mod doc;
 
+#[cfg(feature = "stdlib-bytecode")]
 /// Provides a precompiled bundle of bytecode modules.
 pub fn move_stdlib_bundle() -> &'static [u8] {
     include_bytes!("../build/MoveStdlib/bundles/MoveStdlib.mvb")

--- a/move-vm-backend/Cargo.toml
+++ b/move-vm-backend/Cargo.toml
@@ -15,7 +15,7 @@ move-binary-format = { path = "../language/move-binary-format", default-features
 move-core-types = { path = "../language/move-core/types", default-features = false, features = ["address32"] }
 move-vm-runtime = { path = "../language/move-vm/runtime", default-features = false }
 move-vm-types = { path = "../language/move-vm/types", default-features = false }
-move-stdlib = { path = "../language/move-stdlib", default-features = false, features = ["address32"] }
+move-stdlib = { path = "../language/move-stdlib", default-features = false, features = ["address32", "stdlib-bytecode"] }
 move-vm-backend-common = { path = "../move-vm-backend-common", default-features = false }
 
 [dev-dependencies]

--- a/move-vm-backend/tests/move_vm.rs
+++ b/move-vm-backend/tests/move_vm.rs
@@ -15,7 +15,8 @@ pub mod mock;
 /// Reads bytes from a file for the given path.
 /// Can panic if the file doesn't exist.
 fn read_bytes(file_path: &str) -> Vec<u8> {
-    std::fs::read(file_path).unwrap_or_else(|e| panic!("Can't read {file_path}: {e}"))
+    std::fs::read(file_path)
+        .unwrap_or_else(|e| panic!("Can't read {file_path}: {e} - make sure you run move-vm-backend/tests/assets/move-projects/smove-build-all.sh"))
 }
 
 /// Reads a precompiled Move module from our assets directory.


### PR DESCRIPTION
Since `smove` depends on `move-stdlib`, and then `move-stdlib` needs to use `smove` to compile the bundle - we need to break that cyclic dependency.

This is done with a new feature called `stdlib-bytecode`.
So if any crates need a compiled stdlib bytecode (e.g. `move-vm-backend`), they'll get it by enabling this feature.