### PR TITLE
feat: apply custom gas strategy 

### DIFF
--- a/.github/workflows/check-move-backend-pull-request.yml
+++ b/.github/workflows/check-move-backend-pull-request.yml
@@ -30,4 +30,4 @@ jobs:
       - uses: ./.github/actions/build-setup
 
       - name: Run move-vm-backend tests
-        run: cargo test -p move-vm-backend
+        run: cargo test -p move-vm-backend --features build-move-projects-for-test

--- a/move-vm-backend/Cargo.toml
+++ b/move-vm-backend/Cargo.toml
@@ -9,21 +9,25 @@ description = "MoveVM backend to be used with Substrate pallet"
 
 [dependencies]
 anyhow = { version = "1.0", default-features = false }
-serde = { version = "1.0", default-features = false, features = ["derive"] }
 bcs = { git = "https://github.com/eigerco/bcs.git", default-features = false, branch = "master" }
+lazy_static = { version = "1.4", default-features = false, features = ["spin_no_std"] }
 move-binary-format = { path = "../language/move-binary-format", default-features = false }
 move-core-types = { path = "../language/move-core/types", default-features = false, features = ["address32"] }
-move-vm-runtime = { path = "../language/move-vm/runtime", default-features = false }
-move-vm-types = { path = "../language/move-vm/types", default-features = false }
 move-stdlib = { path = "../language/move-stdlib", default-features = false, features = ["address32", "stdlib-bytecode"] }
-move-vm-backend-common = { path = "../move-vm-backend-common", default-features = false }
-lazy_static = { version = "1.4", default-features = false, features = ["spin_no_std"] }
+move-vm-backend-common = { path = "../move-vm-backend-common", default-features = false, features = ["gas_schedule"] }
+move-vm-runtime = { path = "../language/move-vm/runtime", default-features = false }
+move-vm-test-utils = { path = "../language//move-vm/test-utils", default-features = false }
+move-vm-types = { path = "../language/move-vm/types", default-features = false }
+serde = { version = "1.0", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
 move-vm-test-utils = { path = "../language/move-vm/test-utils" }
 
 [features]
 default = ["std"]
+
+# Builds move projects for test purposes.
+build-move-projects-for-test = []
 
 std = [
     "anyhow/std",

--- a/move-vm-backend/build.rs
+++ b/move-vm-backend/build.rs
@@ -3,9 +3,8 @@ use std::process::Command;
 
 fn main() -> Result<(), Box<dyn Error>> {
     // Build move projects for the test purposes.
-    if std::env::var("PROFILE").unwrap() == "debug" {
-        build_move_projects()?;
-    }
+    #[cfg(feature = "build-move-projects-for-test")]
+    build_move_projects()?;
 
     // SMOVE build our deposit code
     Command::new("smove")

--- a/move-vm-backend/src/types.rs
+++ b/move-vm-backend/src/types.rs
@@ -68,3 +68,23 @@ impl VmResult {
         !self.is_ok()
     }
 }
+
+/// Gas is a resource-fuel for executing Move scripts.
+#[derive(Debug, Clone, Copy)]
+pub enum GasStrategy {
+    /// A metered gas with a provided limit.
+    ///
+    /// If the provided gas is not enough to execute the script or publish the script, then the
+    /// MoveVM will return the out-of-gas error message.
+    ///
+    /// This should be the standard option for the MoveVM.
+    Metered(u64),
+    /// It allows to run Move operations with an infinite amount of gas.
+    ///
+    /// This option should be used to estimate the required gas for the given MoveVM operation.
+    DryRun,
+    /// It allows to run the Move operations with the gas handling disabled.
+    ///
+    /// This option should be used only for testing and debugging purposes.
+    Unmetered,
+}

--- a/move-vm-backend/src/warehouse.rs
+++ b/move-vm-backend/src/warehouse.rs
@@ -9,7 +9,6 @@ use alloc::{
         btree_map::Entry::{Occupied, Vacant},
         BTreeMap,
     },
-    string::ToString,
     vec,
     vec::Vec,
 };
@@ -104,7 +103,7 @@ impl<S: Storage /*, Api: SubstrateAPI*/> Warehouse<S /*, Api*/> {
                 match res {
                     New(ref data) | Modify(ref data) => {
                         if let Ok(deposit) = bcs::from_bytes::<Deposit>(data) {
-                            let (destination, amount) = deposit.into();
+                            let (_destination, _amount) = deposit.into();
                             // make actual transaction using SubstrateApi
                             /*self.substrate_api
                             .transfer(account, destination, amount)

--- a/move-vm-backend/tests/mock.rs
+++ b/move-vm-backend/tests/mock.rs
@@ -1,4 +1,4 @@
-use move_core_types::account_address::AccountAddress;
+//use move_core_types::account_address::AccountAddress;
 use move_vm_backend::storage::Storage;
 //use move_vm_backend::{SubstrateAPI, TransferError};
 use std::cell::RefCell;


### PR DESCRIPTION
Use a custom gas strategy:
- backend API updated to use GasStrategy enum
- use a custom gas table/strategy provided by the `move-vm-backend-common`
- a new test written with a metered gas

Small extra changes:
- removed unused imports
- removed some bits that will never be used
- again using the `build-move-projects-for-test feature` since:
  - it's speeds up the build
  - constantly compiling the same Move packages (in `tests/assets`) somehow
    messes up the cache in `~/.move`. So, not compiling those
    packages on every run help a lot.