### PR TITLE
feat(no-std): adapt move-vm-test-utils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4110,11 +4110,11 @@ name = "move-vm-test-utils"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "lazy_static 1.4.0",
  "move-binary-format",
  "move-core-types",
  "move-table-extension",
  "move-vm-types",
- "once_cell",
  "serde 1.0.193",
 ]
 

--- a/language/move-vm/test-utils/Cargo.toml
+++ b/language/move-vm/test-utils/Cargo.toml
@@ -8,19 +8,23 @@ homepage = "https://diem.com"
 license = "Apache-2.0"
 publish = false
 edition = "2021"
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.52"
-once_cell = "1.7.2"
-serde = { version = "1.0.124", features = ["derive", "rc"] }
+anyhow = { version = "1.0", default-features = false }
+lazy_static = { version = "1.4", default-features = false, features = ["spin_no_std"] }
 
-move-binary-format = { path = "../../move-binary-format" }
-move-core-types = {path = "../../move-core/types" }
-move-vm-types = { path = "../types" }
+move-binary-format = { path = "../../move-binary-format", default-features = false }
+move-core-types = { path = "../../move-core/types", default-features = false }
 move-table-extension = { path = "../../extensions/move-table-extension", optional = true }
+move-vm-types = { path = "../types", default-features = false }
+serde = { version = "1.0", default-features = false, features = ["derive", "rc"] }
 
 [features]
-default = [ ]
-table-extension = [ "move-table-extension" ]
+default = ["std"]
+table-extension = ["move-table-extension"]
+std = [
+    "move-binary-format/std",
+    "move-core-types/std",
+    "move-vm-types/std",
+]

--- a/language/move-vm/test-utils/src/lib.rs
+++ b/language/move-vm/test-utils/src/lib.rs
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![allow(clippy::new_without_default)]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
 
 mod storage;
 

--- a/language/move-vm/test-utils/src/storage.rs
+++ b/language/move-vm/test-utils/src/storage.rs
@@ -2,6 +2,12 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::alloc::borrow::ToOwned;
+use alloc::vec::Vec;
+use alloc::{
+    collections::{btree_map, BTreeMap},
+    fmt::Debug,
+};
 use anyhow::{bail, Result};
 use move_core_types::{
     account_address::AccountAddress,
@@ -9,10 +15,6 @@ use move_core_types::{
     identifier::Identifier,
     language_storage::{ModuleId, StructTag},
     resolver::{ModuleResolver, MoveResolver, ResourceResolver},
-};
-use std::{
-    collections::{btree_map, BTreeMap},
-    fmt::Debug,
 };
 
 #[cfg(feature = "table-extension")]

--- a/move-vm-backend-common/src/gas_schedule.rs
+++ b/move-vm-backend-common/src/gas_schedule.rs
@@ -5,6 +5,7 @@
 //! This module lays out the basic abstract costing schedule for bytecode instructions and for the
 //! native functions.
 
+use alloc::vec;
 use lazy_static::lazy_static;
 use move_binary_format::{
     file_format::{

--- a/move-vm-backend/Cargo.toml
+++ b/move-vm-backend/Cargo.toml
@@ -16,7 +16,7 @@ move-core-types = { path = "../language/move-core/types", default-features = fal
 move-stdlib = { path = "../language/move-stdlib", default-features = false, features = ["address32", "stdlib-bytecode"] }
 move-vm-backend-common = { path = "../move-vm-backend-common", default-features = false, features = ["gas_schedule"] }
 move-vm-runtime = { path = "../language/move-vm/runtime", default-features = false }
-move-vm-test-utils = { path = "../language//move-vm/test-utils", default-features = false }
+move-vm-test-utils = { path = "../language/move-vm/test-utils", default-features = false }
 move-vm-types = { path = "../language/move-vm/types", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 

--- a/move-vm-backend/tests/move_vm.rs
+++ b/move-vm-backend/tests/move_vm.rs
@@ -399,5 +399,8 @@ fn execute_function_test_without_enough_gas() {
     let params: Vec<&[u8]> = vec![&addr_param];
     let result = vm.execute_function(address, mod_name, func_name, type_args, params, gas);
 
-    assert!(result.is_err(), "script execution succeeded with small amount of gas");
+    assert!(
+        result.is_err(),
+        "script execution succeeded with small amount of gas"
+    );
 }


### PR DESCRIPTION
A quick one - we need to ensure `move-vm-test-utils` which is now included in `move-vm-backend` is also no-std compatible.