### PR TITLE
feat: add substrate-stdlib support

### DIFF
--- a/language/move-stdlib/.gitignore
+++ b/language/move-stdlib/.gitignore
@@ -1,0 +1,1 @@
+substrate-stdlib/

--- a/language/move-stdlib/build.rs
+++ b/language/move-stdlib/build.rs
@@ -10,13 +10,12 @@ fn main() -> Result<(), Box<dyn Error>> {
 
 #[allow(dead_code)]
 fn build_stdlib_with_smove() -> Result<(), Box<dyn Error>> {
-    let smove_run = Command::new("smove")
-        .args(["bundle"])
+    let run_build_stdlib_script = Command::new("bash")
+        .args(["build_stdlid_with_smove.sh"])
         .output()
         .expect("failed to execute process");
-
-    if !smove_run.status.success() {
-        let stderr = std::str::from_utf8(&smove_run.stderr)?;
+    if !run_build_stdlib_script.status.success() {
+        let stderr = std::str::from_utf8(&run_build_stdlib_script.stderr)?;
 
         let e = Box::<dyn Error + Send + Sync>::from(stderr);
         return Err(e);

--- a/language/move-stdlib/build_stdlid_with_smove.sh
+++ b/language/move-stdlib/build_stdlid_with_smove.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Build the move-stdlib bundle
+# Comment: source files could eventually be moved to another repo.
+smove bundle
+
+# Build the substrate-stdlib bundle
+pushd .
+rm -rf substrate-stdlib
+git clone https://github.com/eigerco/substrate-stdlib.git
+cd substrate-stdlib
+smove bundle
+popd

--- a/language/move-stdlib/src/lib.rs
+++ b/language/move-stdlib/src/lib.rs
@@ -19,7 +19,13 @@ pub mod natives;
 pub mod doc;
 
 #[cfg(feature = "stdlib-bytecode")]
-/// Provides a precompiled bundle of bytecode modules.
+/// Provides a precompiled bundle of move-stdlib bytecode modules.
 pub fn move_stdlib_bundle() -> &'static [u8] {
     include_bytes!("../build/MoveStdlib/bundles/MoveStdlib.mvb")
+}
+
+#[cfg(feature = "stdlib-bytecode")]
+/// Provides a precompiled bundle of substrate-stdlib bytecode modules.
+pub fn substrate_stdlib_bundle() -> &'static [u8] {
+    include_bytes!("../substrate-stdlib/build/substrate-stdlib/bundles/substrate-stdlib.mvb")
 }

--- a/move-vm-backend/tests/mock.rs
+++ b/move-vm-backend/tests/mock.rs
@@ -3,17 +3,18 @@ use move_vm_backend::storage::Storage;
 //use move_vm_backend::{SubstrateAPI, TransferError};
 use std::cell::RefCell;
 use std::collections::HashMap;
+use std::rc::Rc;
 
 // Mock storage implementation for testing
 #[derive(Clone, Debug)]
 pub struct StorageMock {
-    pub data: RefCell<HashMap<Vec<u8>, Vec<u8>>>,
+    pub data: Rc<RefCell<HashMap<Vec<u8>, Vec<u8>>>>,
 }
 
 impl StorageMock {
     pub fn new() -> StorageMock {
         StorageMock {
-            data: RefCell::new(Default::default()),
+            data: Rc::new(RefCell::new(Default::default())),
         }
     }
 }


### PR DESCRIPTION
- inclusion of substrate-stdlib bytecode in the move-stdlib crate.
- genesis configuration updated with substrate-stdlib support.
- tests for genesis configuration.