### PR TITLE
feat: native function suport for balance module 

### DIFF
--- a/language/move-stdlib/src/natives/balance.rs
+++ b/language/move-stdlib/src/natives/balance.rs
@@ -1,0 +1,147 @@
+// Copyright (c) Eiger, Equilibrium Group
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::natives::helpers::make_module_natives;
+use alloc::string::String;
+use alloc::vec::Vec;
+use alloc::{collections::VecDeque, sync::Arc};
+use move_binary_format::errors::PartialVMResult;
+use move_core_types::account_address::AccountAddress;
+use move_core_types::gas_algebra::InternalGas;
+use move_vm_runtime::native_functions::{NativeContext, NativeFunction};
+use move_vm_types::values::SignerRef;
+use move_vm_types::{
+    loaded_data::runtime_types::Type, natives::function::NativeResult, pop_arg, values::Value,
+};
+
+/***************************************************************************************************
+ * native fun transfer
+ *
+ *   gas cost: base_cost
+ *
+ **************************************************************************************************/
+#[derive(Debug, Clone)]
+pub struct TransferGasParameters {
+    pub base: InternalGas,
+}
+
+pub fn native_transfer(
+    gas_params: &TransferGasParameters,
+    _context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert!(ty_args.is_empty());
+    debug_assert!(args.len() == 3);
+
+    let _amount = pop_arg!(args, u128);
+    let _dst = pop_arg!(args, AccountAddress);
+    let src = pop_arg!(args, SignerRef);
+    let _src = src.address()?;
+
+    NativeResult::map_partial_vm_result_one(gas_params.base, Ok(Value::bool(true)))
+}
+
+pub fn make_native_transfer(gas_params: TransferGasParameters) -> NativeFunction {
+    Arc::new(
+        move |context, ty_args, args| -> PartialVMResult<NativeResult> {
+            native_transfer(&gas_params, context, ty_args, args)
+        },
+    )
+}
+
+/***************************************************************************************************
+ * native fun cheque_amount
+ *
+ *   gas cost: base_cost
+ *
+ **************************************************************************************************/
+#[derive(Debug, Clone)]
+pub struct ChequeAmountGasParameters {
+    pub base: InternalGas,
+}
+
+pub fn native_cheque_amount(
+    gas_params: &ChequeAmountGasParameters,
+    _context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert!(ty_args.is_empty());
+    debug_assert!(args.len() == 1);
+
+    let _dst = pop_arg!(args, AccountAddress);
+
+    // TODO: ...
+
+    NativeResult::map_partial_vm_result_one(gas_params.base, Ok(Value::u128(0)))
+}
+
+pub fn make_native_cheque_amount(gas_params: ChequeAmountGasParameters) -> NativeFunction {
+    Arc::new(
+        move |context, ty_args, args| -> PartialVMResult<NativeResult> {
+            native_cheque_amount(&gas_params, context, ty_args, args)
+        },
+    )
+}
+
+/***************************************************************************************************
+ * native fun total_amount
+ *
+ *   gas cost: base_cost
+ *
+ **************************************************************************************************/
+#[derive(Debug, Clone)]
+pub struct TotalAmountGasParameters {
+    pub base: InternalGas,
+}
+
+pub fn native_total_amount(
+    gas_params: &TotalAmountGasParameters,
+    _context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert!(ty_args.is_empty());
+    debug_assert!(args.len() == 1);
+
+    let _dst = pop_arg!(args, AccountAddress);
+
+    // TODO: ...
+
+    NativeResult::map_partial_vm_result_one(gas_params.base, Ok(Value::u128(0)))
+}
+
+pub fn make_native_total_amount(gas_params: TotalAmountGasParameters) -> NativeFunction {
+    Arc::new(
+        move |context, ty_args, args| -> PartialVMResult<NativeResult> {
+            native_total_amount(&gas_params, context, ty_args, args)
+        },
+    )
+}
+
+/***************************************************************************************************
+ * module
+ **************************************************************************************************/
+#[derive(Debug, Clone)]
+pub struct GasParameters {
+    pub transfer: TransferGasParameters,
+    pub cheque_amount: ChequeAmountGasParameters,
+    pub total_amount: TotalAmountGasParameters,
+}
+
+pub fn make_all(gas_params: GasParameters) -> impl Iterator<Item = (String, NativeFunction)> {
+    let natives = [
+        ("transfer", make_native_transfer(gas_params.transfer)),
+        (
+            "cheque_amount",
+            make_native_cheque_amount(gas_params.cheque_amount),
+        ),
+        (
+            "total_amount",
+            make_native_total_amount(gas_params.total_amount),
+        ),
+    ];
+
+    make_module_natives(natives)
+}

--- a/language/move-stdlib/src/natives/balance.rs
+++ b/language/move-stdlib/src/natives/balance.rs
@@ -74,7 +74,7 @@ pub fn native_cheque_amount(
 
     // TODO: ...
 
-    NativeResult::map_partial_vm_result_one(gas_params.base, Ok(Value::u128(0)))
+    NativeResult::map_partial_vm_result_one(gas_params.base, Ok(Value::u128(11)))
 }
 
 pub fn make_native_cheque_amount(gas_params: ChequeAmountGasParameters) -> NativeFunction {
@@ -109,7 +109,7 @@ pub fn native_total_amount(
 
     // TODO: ...
 
-    NativeResult::map_partial_vm_result_one(gas_params.base, Ok(Value::u128(0)))
+    NativeResult::map_partial_vm_result_one(gas_params.base, Ok(Value::u128(99)))
 }
 
 pub fn make_native_total_amount(gas_params: TotalAmountGasParameters) -> NativeFunction {

--- a/language/move-stdlib/src/natives/mod.rs
+++ b/language/move-stdlib/src/natives/mod.rs
@@ -2,6 +2,7 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod balance;
 pub mod bcs;
 pub mod debug;
 pub mod event;
@@ -27,6 +28,7 @@ pub struct GasParameters {
     pub string: string::GasParameters,
     pub type_name: type_name::GasParameters,
     pub vector: vector::GasParameters,
+    pub balance: balance::GasParameters,
 
     #[cfg(feature = "testing")]
     pub unit_test: unit_test::GasParameters,
@@ -92,6 +94,11 @@ impl GasParameters {
                 destroy_empty: vector::DestroyEmptyGasParameters { base: 0.into() },
                 swap: vector::SwapGasParameters { base: 0.into() },
             },
+            balance: balance::GasParameters {
+                transfer: balance::TransferGasParameters { base: 0.into() },
+                cheque_amount: balance::ChequeAmountGasParameters { base: 0.into() },
+                total_amount: balance::TotalAmountGasParameters { base: 0.into() },
+            },
             #[cfg(feature = "testing")]
             unit_test: unit_test::GasParameters {
                 create_signers_for_testing: unit_test::CreateSignersForTestingGasParameters {
@@ -123,6 +130,7 @@ pub fn all_natives(
     add_natives!("string", string::make_all(gas_params.string));
     add_natives!("type_name", type_name::make_all(gas_params.type_name));
     add_natives!("vector", vector::make_all(gas_params.vector));
+    add_natives!("balance", balance::make_all(gas_params.balance));
     #[cfg(feature = "testing")]
     {
         add_natives!("unit_test", unit_test::make_all(gas_params.unit_test));

--- a/language/move-vm/types/src/values/values_impl.rs
+++ b/language/move-vm/types/src/values/values_impl.rs
@@ -968,6 +968,27 @@ impl SignerRef {
     pub fn borrow_signer(&self) -> PartialVMResult<Value> {
         Ok(Value(self.0.borrow_elem(0)?))
     }
+
+    pub fn address(&self) -> PartialVMResult<AccountAddress> {
+        match self.0.container() {
+            Container::Struct(a) => {
+                let addr = a.borrow();
+                if addr.len() != 1 {
+                    return Err(PartialVMError::new(StatusCode::TOO_MANY_PARAMETERS));
+                }
+
+                match &addr[0] {
+                    ValueImpl::Address(addr) => Ok(*addr),
+                    _ => Err(PartialVMError::new(
+                        StatusCode::UNABLE_TO_DESERIALIZE_ACCOUNT,
+                    )),
+                }
+            }
+            _ => Err(PartialVMError::new(
+                StatusCode::INVALID_PARAM_TYPE_FOR_DESERIALIZATION,
+            )),
+        }
+    }
 }
 
 /***************************************************************************************

--- a/move-vm-backend-common/src/gas_schedule.rs
+++ b/move-vm-backend-common/src/gas_schedule.rs
@@ -215,6 +215,11 @@ lazy_static! {
                 destroy_empty: move_stdlib::natives::vector::DestroyEmptyGasParameters { base: 1000.into() },
                 swap: move_stdlib::natives::vector::SwapGasParameters { base: 1000.into() },
             },
+            balance: move_stdlib::natives::balance::GasParameters {
+                transfer: move_stdlib::natives::balance::TransferGasParameters { base: 1000.into() },
+                cheque_amount: move_stdlib::natives::balance::ChequeAmountGasParameters { base: 1000.into() },
+                total_amount: move_stdlib::natives::balance::TotalAmountGasParameters { base: 1000.into() },
+            },
             #[cfg(feature = "testing")]
             unit_test: move_stdlib::natives::unit_test::GasParameters {
                 create_signers_for_testing: move_stdlib::natives::unit_test::CreateSignersForTestingGasParameters {

--- a/move-vm-backend/src/genesis.rs
+++ b/move-vm-backend/src/genesis.rs
@@ -78,8 +78,7 @@ impl VmGenesisConfig {
         };
 
         publish_under_stdaddr(&self.stdlib_bundle)?;
-        // TODO(rqnsom): uncommment once we have native functions implemented
-        //publish_under_stdaddr(&self.substrate_stdlib_bundle)?;
+        publish_under_stdaddr(&self.substrate_stdlib_bundle)?;
 
         // In case of the successful initialization, apply changes to the storage.
         storage_safe.apply_changes();

--- a/move-vm-backend/tests/assets/move-projects/smove-build-all.sh
+++ b/move-vm-backend/tests/assets/move-projects/smove-build-all.sh
@@ -3,7 +3,16 @@
 # Position the cwd in the same folder with the script (where the below folders are located)
 cd $(dirname $0)
 
-build_dir=("address_checks" "basic_coin" "depends_on__using_stdlib_full" "depends_on__using_stdlib_natives" "empty" "simple_scripts" "using_stdlib_full")
+build_dir=(
+    "address_checks"
+    "basic_coin"
+    "depends_on__using_stdlib_full"
+    "depends_on__using_stdlib_natives"
+    "empty"
+    "simple_scripts"
+    "using_stdlib_full"
+    "substrate_balance"
+)
 bundle_dir=("using_stdlib_natives")
 
 # Build simple packages

--- a/move-vm-backend/tests/assets/move-projects/substrate_balance/Move.toml
+++ b/move-vm-backend/tests/assets/move-projects/substrate_balance/Move.toml
@@ -1,0 +1,11 @@
+[package]
+name = "substrate_balance"
+version = "0.0.0"
+
+[dependencies]
+MoveStdlib = { git = "https://github.com/eigerco/substrate-move.git", subdir = "language/move-stdlib", rev = "main" }
+substrate-stdlib = { git = "https://github.com/eigerco/substrate-stdlib.git", rev = "main" }
+
+[addresses]
+std = "0x1"
+substrate = "0x1"

--- a/move-vm-backend/tests/assets/move-projects/substrate_balance/sources/Transfer.move
+++ b/move-vm-backend/tests/assets/move-projects/substrate_balance/sources/Transfer.move
@@ -1,0 +1,32 @@
+script {
+    use substrate::balance;
+    use std::string;
+
+    fun balance_simple_api_test(src: signer, dst: address, amount: u128) {
+        // Test that the move-stdlib works fine.
+        // Since both these stdlib bundles are published under the same address.
+        //
+        // Create a random string and do some random string operations.
+        let s = string::utf8(b"abcd");
+        let sub = string::sub_string(&s, 4, 4);
+        assert!(string::is_empty(&sub), 22);
+
+        // Test cheque_amount function.
+        let cheque_amount = balance::cheque_amount(@0xCAFE);
+        assert!(cheque_amount == 11, 0);
+
+        // Test total_amount function.
+        let total_amount = balance::total_amount(@0xCAFE);
+        assert!(total_amount == 99, 0);
+
+        // Test transfer function.
+        let ret = balance::transfer(&src, dst, amount);
+        assert!(ret, 0);
+    }
+}
+
+script {
+    fun execute_transfer(_src: signer, _dst: address, _amount: u128) {
+        // TBD
+    }
+}

--- a/move-vm-backend/tests/move_vm.rs
+++ b/move-vm-backend/tests/move_vm.rs
@@ -527,8 +527,6 @@ fn dry_run_gas_strategy_doesnt_update_storage() {
 }
 
 #[test]
-#[should_panic]
-// TODO(rqnsom): this one should not panic once the native functions are implemented
 fn manually_publish_substrate_stdlib_bundle() {
     let store = StorageMock::new();
     let vm = Mvm::new(store /*, SimpleSubstrateApiMock {}*/).unwrap();


### PR DESCRIPTION
- Basic native function support for substrate-stdlib::balance module
  which allows functions to be called inside Move scripts.
- test: add substrate-stdlib balance module basic tests
