### PR TITLE
feat: add balance resolver

### DIFF
--- a/language/move-core/types/src/resolver.rs
+++ b/language/move-core/types/src/resolver.rs
@@ -45,15 +45,53 @@ pub trait ResourceResolver {
     ) -> Result<Option<Vec<u8>>, Self::Error>;
 }
 
+/// A balance backend that can resolve balance handling.
+pub trait BalanceResolver {
+    type Error: Debug;
+
+    /// Resolver should update the inner state for the external balance handler.
+    ///
+    /// Once the MoveVM execution is complete, the data updated by this resolver should be used
+    /// to execute the actual transfers.
+    ///
+    /// The cheque amount is the amount the account is allowed to transfer within the current execution
+    /// context.
+    fn transfer(
+        &self,
+        src: AccountAddress,
+        dst: AccountAddress,
+        cheque_amount: u128,
+    ) -> Result<bool, Self::Error>;
+
+    /// Resolver should return the current cheque amount for a given address.
+    ///
+    /// The cheque amount is the amount the account is allowed to transfer within the current execution
+    /// context.
+    fn cheque_amount(&self, account: AccountAddress) -> Result<u128, Self::Error>;
+
+    /// Resolver should return a total amount for a given address.
+    ///
+    /// The total amount is the amount the account owns.
+    /// Account is allowed to transfer a bit of the total amount with the cheque.
+    fn total_amount(&self, account: AccountAddress) -> Result<u128, Self::Error>;
+}
+
 /// A persistent storage implementation that can resolve both resources and modules
 pub trait MoveResolver:
-    ModuleResolver<Error = Self::Err> + ResourceResolver<Error = Self::Err>
+    ModuleResolver<Error = Self::Err>
+    + ResourceResolver<Error = Self::Err>
+    + BalanceResolver<Error = Self::Err>
 {
     type Err: Debug;
 }
 
-impl<E: Debug, T: ModuleResolver<Error = E> + ResourceResolver<Error = E> + ?Sized> MoveResolver
-    for T
+impl<
+        E: Debug,
+        T: ModuleResolver<Error = E>
+            + ResourceResolver<Error = E>
+            + BalanceResolver<Error = E>
+            + ?Sized,
+    > MoveResolver for T
 {
     type Err = E;
 }
@@ -75,4 +113,49 @@ impl<T: ModuleResolver + ?Sized> ModuleResolver for &T {
     fn get_module(&self, module_id: &ModuleId) -> Result<Option<Vec<u8>>, Self::Error> {
         (**self).get_module(module_id)
     }
+}
+
+impl<T: BalanceResolver + ?Sized> BalanceResolver for &T {
+    type Error = T::Error;
+    fn transfer(
+        &self,
+        src: AccountAddress,
+        dst: AccountAddress,
+        cheque_amount: u128,
+    ) -> Result<bool, Self::Error> {
+        (**self).transfer(src, dst, cheque_amount)
+    }
+    fn cheque_amount(&self, account: AccountAddress) -> Result<u128, Self::Error> {
+        (**self).cheque_amount(account)
+    }
+    fn total_amount(&self, account: AccountAddress) -> Result<u128, Self::Error> {
+        (**self).total_amount(account)
+    }
+}
+
+// Most existing tests won't need this Resolver so here's a quick solution for simple structs to make those test work.
+#[macro_export]
+macro_rules! quick_balance_resolver_impl {
+    ($structname: ident, $error_type:tt) => {
+        impl BalanceResolver for $structname {
+            type Error = $error_type;
+
+            fn transfer(
+                &self,
+                _src: AccountAddress,
+                _dst: AccountAddress,
+                _cheque_amount: u128,
+            ) -> Result<bool, Self::Error> {
+                unimplemented!("shouldn't be used");
+            }
+
+            fn cheque_amount(&self, _account: AccountAddress) -> Result<u128, Self::Error> {
+                unimplemented!("shouldn't be used");
+            }
+
+            fn total_amount(&self, _account: AccountAddress) -> Result<u128, Self::Error> {
+                unimplemented!("shouldn't be used");
+            }
+        }
+    };
 }

--- a/language/move-stdlib/src/natives/balance.rs
+++ b/language/move-stdlib/src/natives/balance.rs
@@ -27,19 +27,21 @@ pub struct TransferGasParameters {
 
 pub fn native_transfer(
     gas_params: &TransferGasParameters,
-    _context: &mut NativeContext,
+    context: &mut NativeContext,
     ty_args: Vec<Type>,
     mut args: VecDeque<Value>,
 ) -> PartialVMResult<NativeResult> {
     debug_assert!(ty_args.is_empty());
     debug_assert!(args.len() == 3);
 
-    let _amount = pop_arg!(args, u128);
-    let _dst = pop_arg!(args, AccountAddress);
+    let amount = pop_arg!(args, u128);
+    let dst = pop_arg!(args, AccountAddress);
     let src = pop_arg!(args, SignerRef);
-    let _src = src.address()?;
 
-    NativeResult::map_partial_vm_result_one(gas_params.base, Ok(Value::bool(true)))
+    let src = src.address()?;
+    let ret = context.transfer(src, dst, amount)?;
+
+    NativeResult::map_partial_vm_result_one(gas_params.base, Ok(Value::bool(ret)))
 }
 
 pub fn make_native_transfer(gas_params: TransferGasParameters) -> NativeFunction {
@@ -63,18 +65,18 @@ pub struct ChequeAmountGasParameters {
 
 pub fn native_cheque_amount(
     gas_params: &ChequeAmountGasParameters,
-    _context: &mut NativeContext,
+    context: &mut NativeContext,
     ty_args: Vec<Type>,
     mut args: VecDeque<Value>,
 ) -> PartialVMResult<NativeResult> {
     debug_assert!(ty_args.is_empty());
     debug_assert!(args.len() == 1);
 
-    let _dst = pop_arg!(args, AccountAddress);
+    let account_addr = pop_arg!(args, AccountAddress);
 
-    // TODO: ...
+    let ret = context.cheque_amount(account_addr)?;
 
-    NativeResult::map_partial_vm_result_one(gas_params.base, Ok(Value::u128(11)))
+    NativeResult::map_partial_vm_result_one(gas_params.base, Ok(Value::u128(ret)))
 }
 
 pub fn make_native_cheque_amount(gas_params: ChequeAmountGasParameters) -> NativeFunction {
@@ -98,18 +100,18 @@ pub struct TotalAmountGasParameters {
 
 pub fn native_total_amount(
     gas_params: &TotalAmountGasParameters,
-    _context: &mut NativeContext,
+    context: &mut NativeContext,
     ty_args: Vec<Type>,
     mut args: VecDeque<Value>,
 ) -> PartialVMResult<NativeResult> {
     debug_assert!(ty_args.is_empty());
     debug_assert!(args.len() == 1);
 
-    let _dst = pop_arg!(args, AccountAddress);
+    let account_addr = pop_arg!(args, AccountAddress);
 
-    // TODO: ...
+    let ret = context.total_amount(account_addr)?;
 
-    NativeResult::map_partial_vm_result_one(gas_params.base, Ok(Value::u128(99)))
+    NativeResult::map_partial_vm_result_one(gas_params.base, Ok(Value::u128(ret)))
 }
 
 pub fn make_native_total_amount(gas_params: TotalAmountGasParameters) -> NativeFunction {

--- a/language/move-vm/integration-tests/src/tests/bad_storage_tests.rs
+++ b/language/move-vm/integration-tests/src/tests/bad_storage_tests.rs
@@ -9,7 +9,8 @@ use move_core_types::{
     effects::{ChangeSet, Op},
     identifier::Identifier,
     language_storage::{ModuleId, StructTag},
-    resolver::{ModuleResolver, ResourceResolver},
+    quick_balance_resolver_impl,
+    resolver::{BalanceResolver, ModuleResolver, ResourceResolver},
     value::{serialize_values, MoveValue},
     vm_status::{StatusCode, StatusType},
 };
@@ -526,6 +527,9 @@ impl ResourceResolver for BogusStorage {
         Err(PartialVMError::new(self.bad_status_code).finish(Location::Undefined))
     }
 }
+
+// This is not supposed to be used in these tests.
+quick_balance_resolver_impl!(BogusStorage, VMError);
 
 const LIST_OF_ERROR_CODES: &[StatusCode] = &[
     StatusCode::UNKNOWN_VALIDATION_STATUS,

--- a/language/move-vm/runtime/src/data_cache.rs
+++ b/language/move-vm/runtime/src/data_cache.rs
@@ -303,4 +303,27 @@ impl<'r, 'l, S: MoveResolver> DataStore for TransactionDataCache<'r, 'l, S> {
     fn events(&self) -> &Vec<(Vec<u8>, u64, Type, MoveTypeLayout, Value)> {
         &self.event_data
     }
+
+    fn transfer(
+        &self,
+        src: AccountAddress,
+        dst: AccountAddress,
+        cheque_amount: u128,
+    ) -> PartialVMResult<bool> {
+        self.remote
+            .transfer(src, dst, cheque_amount)
+            .map_err(|_| PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR))
+    }
+
+    fn cheque_amount(&self, account: AccountAddress) -> PartialVMResult<u128> {
+        self.remote
+            .cheque_amount(account)
+            .map_err(|_| PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR))
+    }
+
+    fn total_amount(&self, account: AccountAddress) -> PartialVMResult<u128> {
+        self.remote
+            .total_amount(account)
+            .map_err(|_| PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR))
+    }
 }

--- a/language/move-vm/runtime/src/native_functions.rs
+++ b/language/move-vm/runtime/src/native_functions.rs
@@ -180,4 +180,21 @@ impl<'a, 'b> NativeContext<'a, 'b> {
     pub fn gas_balance(&self) -> InternalGas {
         self.gas_balance
     }
+
+    pub fn transfer(
+        &self,
+        src: AccountAddress,
+        dst: AccountAddress,
+        cheque_amount: u128,
+    ) -> PartialVMResult<bool> {
+        self.data_store.transfer(src, dst, cheque_amount)
+    }
+
+    pub fn cheque_amount(&self, account: AccountAddress) -> PartialVMResult<u128> {
+        self.data_store.cheque_amount(account)
+    }
+
+    pub fn total_amount(&self, account: AccountAddress) -> PartialVMResult<u128> {
+        self.data_store.total_amount(account)
+    }
 }

--- a/language/move-vm/runtime/src/unit_tests/vm_arguments_tests.rs
+++ b/language/move-vm/runtime/src/unit_tests/vm_arguments_tests.rs
@@ -19,7 +19,8 @@ use move_core_types::{
     account_address::AccountAddress,
     identifier::{IdentStr, Identifier},
     language_storage::{ModuleId, StructTag, TypeTag},
-    resolver::{ModuleResolver, ResourceResolver},
+    quick_balance_resolver_impl,
+    resolver::{BalanceResolver, ModuleResolver, ResourceResolver},
     u256::U256,
     value::{serialize_values, MoveValue},
     vm_status::{StatusCode, StatusType},
@@ -266,6 +267,9 @@ impl ResourceResolver for RemoteStore {
         Ok(None)
     }
 }
+
+// This is not supposed to be used in these tests.
+quick_balance_resolver_impl!(RemoteStore, VMError);
 
 fn combine_signers_and_args(
     signers: Vec<AccountAddress>,

--- a/language/move-vm/test-utils/src/storage.rs
+++ b/language/move-vm/test-utils/src/storage.rs
@@ -14,7 +14,8 @@ use move_core_types::{
     effects::{AccountChangeSet, ChangeSet, Op},
     identifier::Identifier,
     language_storage::{ModuleId, StructTag},
-    resolver::{ModuleResolver, MoveResolver, ResourceResolver},
+    quick_balance_resolver_impl,
+    resolver::{BalanceResolver, ModuleResolver, MoveResolver, ResourceResolver},
 };
 
 #[cfg(feature = "table-extension")]
@@ -52,6 +53,9 @@ impl ResourceResolver for BlankStorage {
         Ok(None)
     }
 }
+
+// This is not supposed to be used in these tests.
+quick_balance_resolver_impl!(BlankStorage, ());
 
 #[cfg(feature = "table-extension")]
 impl TableResolver for BlankStorage {
@@ -101,6 +105,28 @@ impl<'a, 'b, S: ResourceResolver> ResourceResolver for DeltaStorage<'a, 'b, S> {
         }
 
         self.base.get_resource(address, tag)
+    }
+}
+
+// This is not supposed to be used in these tests.
+impl<'a, 'b, S: BalanceResolver> BalanceResolver for DeltaStorage<'a, 'b, S> {
+    type Error = S::Error;
+
+    fn transfer(
+        &self,
+        _src: AccountAddress,
+        _dst: AccountAddress,
+        _cheque_amount: u128,
+    ) -> Result<bool, Self::Error> {
+        unimplemented!("shouldn't be used");
+    }
+
+    fn cheque_amount(&self, _account: AccountAddress) -> Result<u128, Self::Error> {
+        unimplemented!("shouldn't be used");
+    }
+
+    fn total_amount(&self, _account: AccountAddress) -> Result<u128, Self::Error> {
+        unimplemented!("shouldn't be used");
     }
 }
 
@@ -322,3 +348,6 @@ impl TableResolver for InMemoryStorage {
         Ok(self.tables.get(handle).and_then(|t| t.get(key).cloned()))
     }
 }
+
+// This is not supposed to be used in these tests.
+quick_balance_resolver_impl!(InMemoryStorage, ());

--- a/language/move-vm/types/src/data_store.rs
+++ b/language/move-vm/types/src/data_store.rs
@@ -61,4 +61,22 @@ pub trait DataStore {
     ) -> PartialVMResult<()>;
 
     fn events(&self) -> &Vec<(Vec<u8>, u64, Type, MoveTypeLayout, Value)>;
+
+    // ---
+    // Balance operations
+    // ---
+
+    /// Execute transfer.
+    fn transfer(
+        &self,
+        src: AccountAddress,
+        dst: AccountAddress,
+        cheque_amount: u128,
+    ) -> PartialVMResult<bool>;
+
+    /// Get the current cheque amount for the address.
+    fn cheque_amount(&self, account: AccountAddress) -> PartialVMResult<u128>;
+
+    /// Get the total amount for the address.
+    fn total_amount(&self, account: AccountAddress) -> PartialVMResult<u128>;
 }

--- a/language/tools/move-cli/src/sandbox/utils/on_disk_state_view.rs
+++ b/language/tools/move-cli/src/sandbox/utils/on_disk_state_view.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{BCS_EXTENSION, DEFAULT_BUILD_DIR, DEFAULT_STORAGE_DIR};
-use anyhow::{anyhow, bail, Result};
+use anyhow::{anyhow, bail, Error as AnyhowError, Result};
 use move_binary_format::{
     access::ModuleAccess,
     binary_views::BinaryIndexedView,
@@ -15,8 +15,8 @@ use move_core_types::{
     account_address::AccountAddress,
     identifier::Identifier,
     language_storage::{ModuleId, StructTag, TypeTag},
-    parser,
-    resolver::{ModuleResolver, ResourceResolver},
+    parser, quick_balance_resolver_impl,
+    resolver::{BalanceResolver, ModuleResolver, ResourceResolver},
 };
 use move_disassembler::disassembler::Disassembler;
 use move_ir_types::location::Spanned;
@@ -418,6 +418,9 @@ impl ResourceResolver for OnDiskStateView {
         self.get_resource_bytes(*address, struct_tag.clone())
     }
 }
+
+// This is not supposed to be used in these tests.
+quick_balance_resolver_impl!(OnDiskStateView, AnyhowError);
 
 impl GetModule for &OnDiskStateView {
     type Error = anyhow::Error;

--- a/move-vm-backend/src/warehouse.rs
+++ b/move-vm-backend/src/warehouse.rs
@@ -18,7 +18,7 @@ use move_core_types::effects::{
 };
 use move_core_types::identifier::Identifier;
 use move_core_types::language_storage::{ModuleId, StructTag};
-use move_core_types::resolver::{ModuleResolver, ResourceResolver};
+use move_core_types::resolver::{BalanceResolver, ModuleResolver, ResourceResolver};
 use serde::{Deserialize, Serialize};
 
 /// Structure holding account data which is held under one Move address
@@ -146,5 +146,29 @@ impl<S: Storage /*, Api: SubstrateAPI*/> ResourceResolver for Warehouse<S /*, Ap
 
         // Even if the account is not found, we still return Ok(None) - it's not an error for MoveVM.
         Ok(None)
+    }
+}
+
+impl<S: Storage> BalanceResolver for Warehouse<S> {
+    type Error = Error;
+
+    fn transfer(
+        &self,
+        _src: AccountAddress,
+        _dst: AccountAddress,
+        _cheque_amount: u128,
+    ) -> Result<bool, Self::Error> {
+        // TODO(rqnsam): ...
+        Ok(true)
+    }
+
+    fn cheque_amount(&self, _account: AccountAddress) -> Result<u128, Self::Error> {
+        // TODO(rqnsam): ...
+        Ok(0)
+    }
+
+    fn total_amount(&self, _account: AccountAddress) -> Result<u128, Self::Error> {
+        // TODO(rqnsam): ...
+        Ok(0)
     }
 }

--- a/move-vm-backend/tests/assets/move-projects/substrate_balance/sources/Transfer.move
+++ b/move-vm-backend/tests/assets/move-projects/substrate_balance/sources/Transfer.move
@@ -13,11 +13,11 @@ script {
 
         // Test cheque_amount function.
         let cheque_amount = balance::cheque_amount(@0xCAFE);
-        assert!(cheque_amount == 11, 0);
+        assert!(cheque_amount == 0, 0);
 
         // Test total_amount function.
         let total_amount = balance::total_amount(@0xCAFE);
-        assert!(total_amount == 99, 0);
+        assert!(total_amount == 0, 0);
 
         // Test transfer function.
         let ret = balance::transfer(&src, dst, amount);


### PR DESCRIPTION
Integrate a `BalanceResolver` into the MoveVM so native functions inside the balance module under the substrate-stdlib could perform cheque updates to the external balance handler.