### PR TITLE
feat: add balance trait for the substrate layer 

### DIFF
--- a/language/move-core/types/src/vm_status.rs
+++ b/language/move-core/types/src/vm_status.rs
@@ -687,6 +687,9 @@ pub enum StatusCode {
     RESERVED_RUNTIME_ERROR_4 = 4036,
     RESERVED_RUNTIME_ERROR_5 = 4037,
 
+    // Substrate related codes: 9000-9999
+    INSUFFICIENT_BALANCE = 9000,
+
     // A reserved status to represent an unknown vm status.
     // this is core::u64::MAX, but we can't pattern match on that, so put the hardcoded value in
     UNKNOWN_STATUS = 18446744073709551615,

--- a/language/move-vm/integration-tests/src/tests/bad_storage_tests.rs
+++ b/language/move-vm/integration-tests/src/tests/bad_storage_tests.rs
@@ -529,7 +529,7 @@ impl ResourceResolver for BogusStorage {
 }
 
 // This is not supposed to be used in these tests.
-quick_balance_resolver_impl!(BogusStorage, VMError);
+quick_balance_resolver_impl!(BogusStorage, StatusCode);
 
 const LIST_OF_ERROR_CODES: &[StatusCode] = &[
     StatusCode::UNKNOWN_VALIDATION_STATUS,

--- a/language/move-vm/runtime/src/data_cache.rs
+++ b/language/move-vm/runtime/src/data_cache.rs
@@ -312,7 +312,7 @@ impl<'r, 'l, S: MoveResolver> DataStore for TransactionDataCache<'r, 'l, S> {
     ) -> PartialVMResult<bool> {
         self.remote
             .transfer(src, dst, cheque_amount)
-            .map_err(|_| PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR))
+            .map_err(|e| PartialVMError::new(e.into()))
     }
 
     fn cheque_amount(&self, account: AccountAddress) -> PartialVMResult<u128> {

--- a/language/move-vm/runtime/src/unit_tests/vm_arguments_tests.rs
+++ b/language/move-vm/runtime/src/unit_tests/vm_arguments_tests.rs
@@ -269,7 +269,7 @@ impl ResourceResolver for RemoteStore {
 }
 
 // This is not supposed to be used in these tests.
-quick_balance_resolver_impl!(RemoteStore, VMError);
+quick_balance_resolver_impl!(RemoteStore, StatusCode);
 
 fn combine_signers_and_args(
     signers: Vec<AccountAddress>,

--- a/language/move-vm/test-utils/src/storage.rs
+++ b/language/move-vm/test-utils/src/storage.rs
@@ -16,6 +16,7 @@ use move_core_types::{
     language_storage::{ModuleId, StructTag},
     quick_balance_resolver_impl,
     resolver::{BalanceResolver, ModuleResolver, MoveResolver, ResourceResolver},
+    vm_status::StatusCode,
 };
 
 #[cfg(feature = "table-extension")]
@@ -55,7 +56,7 @@ impl ResourceResolver for BlankStorage {
 }
 
 // This is not supposed to be used in these tests.
-quick_balance_resolver_impl!(BlankStorage, ());
+quick_balance_resolver_impl!(BlankStorage, StatusCode);
 
 #[cfg(feature = "table-extension")]
 impl TableResolver for BlankStorage {
@@ -350,4 +351,4 @@ impl TableResolver for InMemoryStorage {
 }
 
 // This is not supposed to be used in these tests.
-quick_balance_resolver_impl!(InMemoryStorage, ());
+quick_balance_resolver_impl!(InMemoryStorage, StatusCode);

--- a/language/tools/move-cli/src/sandbox/utils/on_disk_state_view.rs
+++ b/language/tools/move-cli/src/sandbox/utils/on_disk_state_view.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{BCS_EXTENSION, DEFAULT_BUILD_DIR, DEFAULT_STORAGE_DIR};
-use anyhow::{anyhow, bail, Error as AnyhowError, Result};
+use anyhow::{anyhow, bail, Result};
 use move_binary_format::{
     access::ModuleAccess,
     binary_views::BinaryIndexedView,
@@ -17,6 +17,7 @@ use move_core_types::{
     language_storage::{ModuleId, StructTag, TypeTag},
     parser, quick_balance_resolver_impl,
     resolver::{BalanceResolver, ModuleResolver, ResourceResolver},
+    vm_status::StatusCode,
 };
 use move_disassembler::disassembler::Disassembler;
 use move_ir_types::location::Spanned;
@@ -420,7 +421,7 @@ impl ResourceResolver for OnDiskStateView {
 }
 
 // This is not supposed to be used in these tests.
-quick_balance_resolver_impl!(OnDiskStateView, AnyhowError);
+quick_balance_resolver_impl!(OnDiskStateView, StatusCode);
 
 impl GetModule for &OnDiskStateView {
     type Error = anyhow::Error;

--- a/move-vm-backend/src/balance.rs
+++ b/move-vm-backend/src/balance.rs
@@ -1,0 +1,44 @@
+use move_core_types::{account_address::AccountAddress, vm_status::StatusCode};
+
+/// Trait for a balance handler.
+///
+/// This is used to provide an access to external balance handling functionality from within the
+/// MoveVM.
+pub trait BalanceHandler {
+    type Error: Into<StatusCode>;
+
+    fn transfer(
+        &self,
+        src: AccountAddress,
+        dst: AccountAddress,
+        cheque_amount: u128,
+    ) -> Result<bool, Self::Error>;
+
+    fn cheque_amount(&self, account: AccountAddress) -> Result<u128, Self::Error>;
+
+    fn total_amount(&self, account: AccountAddress) -> Result<u128, Self::Error>;
+}
+
+/// An unused [`BalanceHandler`] implementation that is needed for special cases (genesis configuration).
+pub(crate) struct DummyBalanceHandler;
+
+impl BalanceHandler for DummyBalanceHandler {
+    type Error = StatusCode;
+
+    fn transfer(
+        &self,
+        _src: AccountAddress,
+        _dst: AccountAddress,
+        _cheque_amount: u128,
+    ) -> Result<bool, Self::Error> {
+        unreachable!()
+    }
+
+    fn cheque_amount(&self, _account: AccountAddress) -> Result<u128, Self::Error> {
+        unreachable!()
+    }
+
+    fn total_amount(&self, _account: AccountAddress) -> Result<u128, Self::Error> {
+        unreachable!()
+    }
+}

--- a/move-vm-backend/src/genesis.rs
+++ b/move-vm-backend/src/genesis.rs
@@ -1,5 +1,6 @@
 //! Provides a configuration to prepare the initial MoveVM storage state.
 
+use crate::balance::DummyBalanceHandler;
 use crate::Mvm;
 use crate::VmResult;
 use crate::{storage::Storage, types::GasStrategy};
@@ -65,7 +66,8 @@ impl VmGenesisConfig {
     /// Apply the configuration to the storage.
     pub fn apply<S: Storage>(self, storage: S) -> Result<(), GenesisConfigError> {
         let storage_safe = StorageSafe::new(storage);
-        let vm = Mvm::new(&storage_safe).map_err(|_| GenesisConfigError::MoveVmInitFailure)?;
+        let vm = Mvm::new(&storage_safe, DummyBalanceHandler {})
+            .map_err(|_| GenesisConfigError::MoveVmInitFailure)?;
 
         let publish_under_stdaddr = |bundle: &[u8]| {
             let result =

--- a/move-vm-backend/tests/assets/move-projects/substrate_balance/sources/Transfer.move
+++ b/move-vm-backend/tests/assets/move-projects/substrate_balance/sources/Transfer.move
@@ -26,7 +26,23 @@ script {
 }
 
 script {
-    fun execute_transfer(_src: signer, _dst: address, _amount: u128) {
-        // TBD
+    use substrate::balance;
+    use std::signer;
+
+    fun execute_transfer(src: signer, dst: address, amount: u128) {
+        let src_addr = signer::address_of(&src);
+
+        let src_cheque_amount = balance::cheque_amount(src_addr);
+        let dst_cheque_amount = balance::cheque_amount(dst);
+        assert!(src_cheque_amount == amount, 0);
+        assert!(dst_cheque_amount == 0, 0);
+
+        let ret = balance::transfer(&src, dst, amount);
+        assert!(ret, 0);
+
+        let src_cheque_amount = balance::cheque_amount(src_addr);
+        let dst_cheque_amount = balance::cheque_amount(dst);
+        assert!(src_cheque_amount == 0, 0);
+        assert!(dst_cheque_amount == amount, 0);
     }
 }

--- a/move-vm-backend/tests/mock.rs
+++ b/move-vm-backend/tests/mock.rs
@@ -1,11 +1,12 @@
-//use move_core_types::account_address::AccountAddress;
+use move_core_types::account_address::AccountAddress;
+use move_core_types::vm_status::StatusCode;
+use move_vm_backend::balance::BalanceHandler;
 use move_vm_backend::storage::Storage;
-//use move_vm_backend::{SubstrateAPI, TransferError};
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
 
-// Mock storage implementation for testing
+// Mock storage implementation for testing.
 #[derive(Clone, Debug)]
 pub struct StorageMock {
     pub data: Rc<RefCell<HashMap<Vec<u8>, Vec<u8>>>>,
@@ -42,30 +43,62 @@ impl Storage for StorageMock {
     }
 }
 
-/*
-pub struct SubstrateApiMock {
-    pub storage: StorageMock,
+// Mock balance handler implementation for testing.
+#[derive(Clone, Debug)]
+pub struct BalanceMock {
+    cheques: Rc<RefCell<HashMap<AccountAddress, u128>>>,
 }
 
-
-impl SubstrateAPI for SubstrateApiMock {
-    fn transfer(
-        &self,
-        _from: AccountAddress,
-        to: AccountAddress,
-        amount: u128,
-    ) -> Result<(), TransferError> {
-        self.storage
-            .set(to.as_slice(), amount.to_be_bytes().as_slice());
-        Ok(())
+impl BalanceMock {
+    pub fn new() -> Self {
+        Self {
+            cheques: Rc::new(RefCell::new(HashMap::new())),
+        }
     }
 
-    fn get_balance(&self, of: AccountAddress) -> u128 {
-        if let Some(b_data) = self.storage.get(of.as_slice()) {
-            u128::from_be_bytes(b_data.try_into().unwrap())
+    pub fn write_cheque(&mut self, account: AccountAddress, amount: u128) {
+        let mut cheques = self.cheques.borrow_mut();
+
+        if let Some(current_amount) = cheques.get_mut(&account) {
+            *current_amount += amount;
         } else {
-            123
+            cheques.insert(account, amount);
         }
     }
 }
-*/
+
+impl BalanceHandler for BalanceMock {
+    type Error = StatusCode;
+
+    fn transfer(
+        &self,
+        src: AccountAddress,
+        dst: AccountAddress,
+        cheque_amount: u128,
+    ) -> Result<bool, Self::Error> {
+        let mut cheques = self.cheques.borrow_mut();
+
+        let src_balance = cheques.entry(src).or_insert(0);
+        if *src_balance < cheque_amount {
+            return Err(StatusCode::INSUFFICIENT_BALANCE);
+        }
+        *src_balance -= cheque_amount;
+
+        if let Some(dst_balance) = cheques.get_mut(&dst) {
+            *dst_balance += cheque_amount;
+        } else {
+            cheques.insert(dst, cheque_amount);
+        }
+
+        Ok(true)
+    }
+
+    fn cheque_amount(&self, account: AccountAddress) -> Result<u128, Self::Error> {
+        Ok(*self.cheques.borrow().get(&account).unwrap_or(&0))
+    }
+
+    fn total_amount(&self, account: AccountAddress) -> Result<u128, Self::Error> {
+        // We won't need it here.
+        self.cheque_amount(account)
+    }
+}


### PR DESCRIPTION
Balance trait can be used to inject an external balance handler inside the MoveVM.
  



_reusing a testing PR that was accidentally published in this repo, sorry for a strange branch name..._