### PR TITLE
chore: use backend-common for `ScriptTransaction`

### DIFF
--- a/move-vm-backend-common/src/types.rs
+++ b/move-vm-backend-common/src/types.rs
@@ -1,5 +1,7 @@
 use alloc::vec::Vec;
 use anyhow::{Error, Result};
+use core::convert::TryFrom;
+use move_core_types::language_storage::TypeTag;
 use serde::{Deserialize, Serialize};
 
 /// Bundle contains a list of module bytecodes.
@@ -31,5 +33,34 @@ impl TryFrom<&[u8]> for ModuleBundle {
 
     fn try_from(blob: &[u8]) -> Result<Self, Self::Error> {
         bcs::from_bytes(blob).map_err(Error::msg)
+    }
+}
+
+/// Transaction representation used in execute call.
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ScriptTransaction {
+    /// Script bytecode.
+    pub bytecode: Vec<u8>,
+    /// All script arguments that are fed to the MoveVM.
+    ///
+    /// Signers in this list are represented with their address - and are actually signed by the
+    /// account that executes the extrinsic in the pallet layer.
+    pub args: Vec<Vec<u8>>,
+    /// Script type arguments.
+    pub type_args: Vec<TypeTag>,
+}
+
+impl TryFrom<&[u8]> for ScriptTransaction {
+    type Error = Error;
+
+    fn try_from(blob: &[u8]) -> Result<Self, Self::Error> {
+        bcs::from_bytes(blob).map_err(Error::msg)
+    }
+}
+
+impl ScriptTransaction {
+    /// Serializes data.
+    pub fn encode(self) -> Result<Vec<u8>> {
+        bcs::to_bytes(&self).map_err(Error::msg)
     }
 }


### PR DESCRIPTION
- This will be used by the `pallet-move` and the `smove` and possibly by the `move-vm-backend`.

So this is the [current location](https://github.com/eigerco/pallet-move/blob/main/src/transaction.rs) for this type, and we are going to remove it from there in the next pallet-move PR.