### PR TITLE
chore(move-vm-types): ensure no-std compatibility

### DIFF
--- a/language/move-vm/types/src/views.rs
+++ b/language/move-vm/types/src/views.rs
@@ -1,12 +1,10 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-extern crate std;
-
 use move_core_types::{
     account_address::AccountAddress, gas_algebra::AbstractMemorySize, language_storage::TypeTag,
 };
-use std::mem::size_of_val;
+use core::mem::size_of_val;
 
 /// Trait that provides an abstract view into a Move type.
 ///


### PR DESCRIPTION
- move-vm-runtime depends on move-vm-types and both are used in the no-std environment within the pallets runtime.