### PR TITLE
chore: harmonise naming style in Move stdlibs

### DIFF
--- a/language/move-stdlib/build_stdlid_with_smove.sh
+++ b/language/move-stdlib/build_stdlid_with_smove.sh
@@ -12,8 +12,8 @@ popd
 
 # Build the substrate-stdlib bundle
 pushd .
-rm -rf substrate-stdlib
-git clone https://github.com/eigerco/substrate-stdlib.git
-cd substrate-stdlib
+rm -rf SubstrateStdlib
+git clone https://github.com/eigerco/substrate-stdlib.git SubstrateStdlib
+cd SubstrateStdlib
 smove bundle
 popd

--- a/language/move-stdlib/src/lib.rs
+++ b/language/move-stdlib/src/lib.rs
@@ -27,5 +27,5 @@ pub fn move_stdlib_bundle() -> &'static [u8] {
 /// Provides a precompiled bundle of substrate-stdlib bytecode modules.
 #[cfg(feature = "stdlib-bytecode")]
 pub fn substrate_stdlib_bundle() -> &'static [u8] {
-    include_bytes!("../substrate-stdlib/build/substrate-stdlib/bundles/substrate-stdlib.mvb")
+    include_bytes!("../SubstrateStdlib/build/SubstrateStdlib/bundles/SubstrateStdlib.mvb")
 }

--- a/language/tools/move-cli/src/sandbox/commands/test.rs
+++ b/language/tools/move-cli/src/sandbox/commands/test.rs
@@ -106,10 +106,7 @@ fn determine_package_nest_depth(
             Ok(r) => r,
             _ => continue,
         };
-        depth = std::cmp::max(
-            depth,
-            stripped_path.components().count() + 1,
-        );
+        depth = std::cmp::max(depth, stripped_path.components().count() + 1);
     }
     Ok(depth)
 }

--- a/move-vm-backend/tests/assets/move-projects/substrate_balance/Move.toml
+++ b/move-vm-backend/tests/assets/move-projects/substrate_balance/Move.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 
 [dependencies]
 MoveStdlib = { git = "https://github.com/eigerco/move-stdlib", rev = "main" }
-substrate-stdlib = { git = "https://github.com/eigerco/substrate-stdlib.git", rev = "main" }
+SubstrateStdlib = { git = "https://github.com/eigerco/substrate-stdlib.git", rev = "main" }
 
 [addresses]
 std = "0x1"


### PR DESCRIPTION
- harmonise naming style of Move-stdlibs, here: `SubstrateStdlib`
- Note: There is one minor `cargo fmt` correction that has been added - too small for a separate PR :blush: