### PR TITLE
feat: integrate base58 encoding support into substrate-move

### DIFF
--- a/language/move-command-line-common/src/address.rs
+++ b/language/move-command-line-common/src/address.rs
@@ -67,6 +67,12 @@ impl NumericalAddress {
                 format: NumberFormat::Ss58,
             });
         }
+        if let Ok(address) = move_vm_support::base58_address::base58_to_move_address(s) {
+            return Ok(NumericalAddress {
+                bytes: address,
+                format: NumberFormat::Base58,
+            });
+        }
         match parse_address_number(s) {
             Some((n, format)) => Ok(NumericalAddress {
                 bytes: AccountAddress::new(n),
@@ -100,6 +106,11 @@ impl fmt::Display for NumericalAddress {
                 write!(f, "{}", n)
             }
             NumberFormat::Hex => write!(f, "{:#X}", self),
+            NumberFormat::Base58 => write!(
+                f,
+                "{}",
+                move_vm_support::base58_address::move_address_to_base58_string(&self.bytes)
+            ),
             NumberFormat::Ss58 => write!(
                 f,
                 "{}",

--- a/language/move-command-line-common/src/parser.rs
+++ b/language/move-command-line-common/src/parser.rs
@@ -337,12 +337,13 @@ pub fn parse_address_impl(tok: ValueToken, contents: &str) -> Result<ParsedAddre
     })
 }
 
+/// Number format enum, the u32 value represents the base
 #[derive(Ord, PartialOrd, Eq, PartialEq, Hash, Clone, Copy)]
 #[repr(u32)]
-/// Number format enum, the u32 value represents the base
 pub enum NumberFormat {
     Decimal = 10,
     Hex = 16,
+    Base58 = 30,
     Ss58 = 32,
 }
 
@@ -416,6 +417,7 @@ pub fn parse_address_number(s: &str) -> Option<([u8; AccountAddress::LENGTH], Nu
         match base {
             NumberFormat::Hex => 16,
             NumberFormat::Decimal => 10,
+            NumberFormat::Base58 => 30,
             NumberFormat::Ss58 => 32,
         },
     )?;

--- a/language/tools/move-package/src/source_package/manifest_parser.rs
+++ b/language/tools/move-package/src/source_package/manifest_parser.rs
@@ -302,6 +302,9 @@ fn parse_address_literal(address_str: &str) -> Result<AccountAddress, AccountAdd
     if let Ok(address) = move_vm_support::ss58_address::ss58_to_move_address(address_str) {
         return Ok(address);
     }
+    if let Ok(address) = move_vm_support::base58_address::base58_to_move_address(address_str) {
+        return Ok(address);
+    }
     let mut address_str = address_str.to_string();
     if !address_str.starts_with("0x") {
         address_str = format!("0x{}", address_str);

--- a/move-vm-backend/tests/assets/move-projects/base58_smove_build/Move.toml
+++ b/move-vm-backend/tests/assets/move-projects/base58_smove_build/Move.toml
@@ -1,0 +1,13 @@
+[package]
+name = "base58_smove_build"
+version = "0.0.0"
+
+[dependencies]
+MoveStdlib = { git = "https://github.com/eigerco/move-stdlib", rev = "main" }
+
+[addresses]
+std =  "0x1"
+# Will be replaced after smove has got updated.
+# Bob = "AbygL37RheNZv327cMvZPqKYLLkZ6wqWYexRxgNiZyeP"
+# Temporary, to be replaced by address above.
+Bob = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"

--- a/move-vm-backend/tests/assets/move-projects/base58_smove_build/sources/BobBase58.move
+++ b/move-vm-backend/tests/assets/move-projects/base58_smove_build/sources/BobBase58.move
@@ -1,0 +1,5 @@
+module Bob::BobBase58 {
+    fun nothing_stupid() {
+        assert!(0 == 0, 0);
+    }
+}

--- a/move-vm-backend/tests/assets/move-projects/smove-build-all.sh
+++ b/move-vm-backend/tests/assets/move-projects/smove-build-all.sh
@@ -5,6 +5,7 @@ cd $(dirname $0)
 
 build_dir=(
     "address_checks"
+    "base58_smove_build"
     "basic_coin"
     "depends_on__using_stdlib_full"
     "depends_on__using_stdlib_natives"

--- a/move-vm-support/src/base58_address.rs
+++ b/move-vm-support/src/base58_address.rs
@@ -162,6 +162,14 @@ mod tests {
             "5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y",
             ss58_address
         );
+
+        // This one is Bob's address for further move-project based testings.
+        let base58_address = "AbygL37RheNZv327cMvZPqKYLLkZ6wqWYexRxgNiZyeP";
+        let ss58_address = base58_string_to_ss588_string(base58_address).unwrap();
+        assert_eq!(
+            "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
+            ss58_address
+        );
     }
 
     #[test]
@@ -177,6 +185,14 @@ mod tests {
         let base58_address = ss58_string_to_base58_string(ss58_address).unwrap();
         assert_eq!(
             "AjtNsBf2JLsVANbtsqLTLrGz5JxDRosGT8XXqn1cPvSd",
+            base58_address
+        );
+
+        // This one is Bob's address for further move-project based testings.
+        let ss58_address = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
+        let base58_address = ss58_string_to_base58_string(ss58_address).unwrap();
+        assert_eq!(
+            "AbygL37RheNZv327cMvZPqKYLLkZ6wqWYexRxgNiZyeP",
             base58_address
         );
     }


### PR DESCRIPTION
- integrate base58 encoding functionality into `move-command-line-common` and `move-package`