### PR TITLE
feat: optimise publishing gas costs

### DIFF
--- a/move-vm-backend-common/src/gas_schedule.rs
+++ b/move-vm-backend-common/src/gas_schedule.rs
@@ -20,7 +20,7 @@ use move_stdlib::natives::GasParameters;
 use move_vm_test_utils::gas_schedule::{new_from_instructions, CostTable, GasCost};
 
 /// A predefined gas cost to published byte ratio.
-pub const GAS_COST_PER_PUBLISHED_BYTE: u64 = 100;
+pub const GAS_COST_PER_PUBLISHED_BYTE: u64 = 10;
 
 /// Generic gas cost table scale factor, that will be applied linearly.
 pub const TABLE_GAS_COST_SCALE_FACTOR: f64 = 1.0;

--- a/move-vm-backend-common/src/gas_schedule.rs
+++ b/move-vm-backend-common/src/gas_schedule.rs
@@ -20,7 +20,7 @@ use move_stdlib::natives::GasParameters;
 use move_vm_test_utils::gas_schedule::{new_from_instructions, CostTable, GasCost};
 
 /// A predefined gas cost to published byte ratio.
-pub const GAS_COST_PER_PUBLISHED_BYTE: u64 = 10;
+pub const MILLIGAS_COST_PER_PUBLISHED_BYTE: u64 = 1000;
 
 /// Generic gas cost table scale factor, that will be applied linearly.
 pub const TABLE_GAS_COST_SCALE_FACTOR: f64 = 1.0;

--- a/move-vm-backend/src/types.rs
+++ b/move-vm-backend/src/types.rs
@@ -5,7 +5,9 @@ use move_core_types::gas_algebra::GasQuantity;
 use move_core_types::identifier::Identifier;
 use move_core_types::language_storage::TypeTag;
 use move_core_types::vm_status::StatusCode;
-use move_vm_backend_common::gas_schedule::{GAS_COST_PER_PUBLISHED_BYTE, INSTRUCTION_COST_TABLE};
+use move_vm_backend_common::gas_schedule::{
+    INSTRUCTION_COST_TABLE, MILLIGAS_COST_PER_PUBLISHED_BYTE,
+};
 use move_vm_test_utils::gas_schedule::GasStatus;
 use move_vm_types::gas::GasMeter;
 
@@ -178,7 +180,7 @@ impl GasHandler<'_> {
         num_bytes: usize,
     ) -> Result<(), VmResult> {
         let remaining_gas = self.status.remaining_gas();
-        let amount = GasQuantity::new(num_bytes as u64 * GAS_COST_PER_PUBLISHED_BYTE);
+        let amount = GasQuantity::new(num_bytes as u64 * MILLIGAS_COST_PER_PUBLISHED_BYTE);
 
         self.status.deduct_gas(amount).map_err(|e| VmResult {
             status_code: e.major_status(),

--- a/move-vm-backend/tests/move_vm.rs
+++ b/move-vm-backend/tests/move_vm.rs
@@ -61,8 +61,8 @@ fn read_script_bytes_from_project(project: &str, script_name: &str) -> Vec<u8> {
 /// Estimate gas for published module / bundle.
 #[inline]
 fn estimate_gas_for_published_bytecode(bytecode: &[u8]) -> u64 {
-    let raw_gas_cost =
-        bytecode.len() as u64 * move_vm_backend_common::gas_schedule::GAS_COST_PER_PUBLISHED_BYTE;
+    let raw_gas_cost = bytecode.len() as u64
+        * move_vm_backend_common::gas_schedule::MILLIGAS_COST_PER_PUBLISHED_BYTE;
     num_integer::div_ceil(raw_gas_cost, 1000)
 }
 


### PR DESCRIPTION
- renamed constant to `MILLIGAS_COST_PER_PUBLISHED_BYTE`
- increased constant by factor 10 after evaluation of gas costs